### PR TITLE
Added custom callback plugin to hide "FAILED-RETRYING" logs for a until-retry operation while performing a non-verbose playbook run

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -152,6 +152,11 @@ The following actions are carried out upon running the playbook :
 - Container to launch FIO is instantiated
 - Cleanup is performed post user confirmation
 
+### LIMITATIONS
+
+Currently, the playbooks are written to work with Ubuntu hosts. They will be enhanced to work on other
+linux flavours soon.
+
 ### SWITCHES AND LATCHES
 
 - Use `-v` flag while running the playbook to enable verbose logging. 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -124,14 +124,15 @@ A brief outline of the functions associated with above components is described b
    
 ### INSTALLATION
 
+The pre-requisites include availability of at-least four linux machines (VMs OR bare-metal boxes,
+to be used as client, Maya-master server, at least two OpenEBS storage hosts respectively) with 
+basic development packages, SSH service & ansible (version >= 2.3) installed (ansible in turn needs 
+python-minimal on the boxes as a pre-requisite). 
+
 The ansible based CI-CD framework for openebs can be installed via a git clone of the elves 
-repository (openebs/elves/ansible). 
+repository (openebs/elves/ansible) into the client machine 
 
 `git clone https://github.com/openebs/elves.git`
-
-The pre-requisites include availability of at-least four linux machines (VMs OR bare-metal boxes) 
-with basic development packages, SSH service & ansible (version >= 2.3) installed 
-(ansible in turn needs python-minimal on the boxes as a pre-requisite).
 
 ### USAGE
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,189 @@
+# ANSIBLE BASED CI-CD FRAMEWORK FOR OPENEBS
+-------------------------------------------
+
+## PURPOSE
+
+This project aims to provide an automated deployment & test framework for OpenEBS 
+using the popular provisioning & configuration management tool Ansible,while using 
+python & shell scripts for auxiliary purposes. This is intended to facilitate quick 
+validation of commits made into openebs repos and keep it free of regression issues.
+
+In its current form, this project performs an automated setup of OpenEBS from a client
+machine - including orchestration engine Maya & storage node cluster, spawns a jiva 
+volume container on the node and runs an FIO workload on block storage after consuming 
+it into a test container. It is expected to evolve to provide more setup & configuration
+options and include a greater number of test scenarios.
+
+### Ansible 
+
+#### Why Ansible
+
+Ansible works in an agentless mode (though it needs python & SSH!) to get tasks 
+executed on multiple hosts simultaneously. It has a rich set of inbuilt modules 
+which cover most of the configuration and deployment steps associated with 
+projects like OpenEBS, with options to execute shell commands/run scripts in cases
+where desired modules are not present. Ansible also supports integration with 
+custom plugins for a wide variety of functions. Add to it the idempotent nature 
+of the task execution, and you have a powerful tool for both CI/CD as well as 
+standalone automation runs.
+
+#### File extensions in Ansible
+
+Ansible uses YAML because it is easier for humans to read and write than other 
+common data formats like XML or JSON. YAML is the format of Ansible's 
+important components, such as playbooks & variable definition files. Ansible also 
+uses .cfg files to store host details (called inventory) and define its own functional 
+parameters (ansible.cfg) 
+
+#### How it works 
+
+Ansible runs a set of "plays" which are a collection of "tasks" - on a group of 
+hosts defined in the inventory (typically, a file called "hosts"). A "playbook" 
+consists of multiple such plays to be executed. Ansible "roles" are reusable 
+abstractions which can be created based on an overall function performed by a set 
+of tasks, and can be included into playbooks.Each role has a default structure with
+vars,defaults,tasks,meta,handler folders, with each containing a "main.yml" file. 
+The vars & defaults folders consist of variables used by the tasks in the role. 
+The meta folder contains role dependencies, i.e., tasks to be run before running 
+current role tasks.The handler takes care of service handling and is invoked by the 
+"notify" keyword inside tasks.
+
+### DIRECTORY LAYOUT OF THE CI-CD PROJECT 
+
+The openebs Ansible project tree is shown below.
+
+```
+ansible
+|
+|
+|__inventory/machines.in, hosts
+|    |__group_vars    {all.yml}
+|   
+|__roles 
+|    |
+|    |__prerequisites {defaults/main.yml, tasks/main.yml}
+|    |__vagrant       {defaults/main.yml, meta/main.yml, tasks/main.yml}
+|    |__inventory     {defaults/main.yml, meta/main.yml, tasks/main.yml}
+|    |__common        {defaults/main.yml, meta/main.yml, tasks/main.yml}
+|    |__master        {defaults/main.yml, meta/main.yml, tasks/main.yml, handlers/main.yml}
+|    |__hosts         {meta/main.yml, tasks/main.yml} 
+|    |__volume        {defaults/main.yml, tasks/main.yml}
+|    |__localhost     {defaults/main.yml, tasks/main.yml} 
+|    |__fio           {defaults/main.yml, tasks/main.yml} 
+|    |__cleanup       {defaults/main.yml, tasks/main.yml}
+|
+|__plugins
+|    |__callback      {openebs.py}
+|
+|__files              {utils.py, generate-inventory.py}
+|
+|__{Vagrantfile}
+|
+|__{ansible.cfg}
+|
+|__{site.yml}
+
+```
+A brief outline of the functions associated with above components is described below : 
+
+#### inventory :
+  This is the default directory that holds the hosts file  
+- machines.in : Input file for inventory file generation 
+- hosts : Default inventory file referred to in the plays
+- group_Vars/all.yml : Contains global variables for playbook run
+
+#### roles : 
+  Contains ansible roles for openebs cluster setup and I/O run
+- prerequisites : Installs python packages necessary for inventory generation
+- inventory : Generates the hosts file based on entries in machines.in. 
+- common : Installs apt packages common to Maya Server & Storage Node cluster
+- master : Installs & configures maya server
+- hosts : Installs & configures openebs storage hosts
+- vagrant : Makes some config changes in maya server & node setup if machines are vagrant VMs
+- volume : Creates a volume according to input parameters in all.yml
+- localhost : Configures the client machine to run FIO container
+- fio : Runs fio profile in a test container after mounting block storage (on client)
+- cleanup : Tear down iSCSI sessions & destroys volume on the storage nodes
+
+#### plugins :
+   Contains custom plugins that can be integrated into Ansible. 
+   Ex: stdout callback
+   
+#### files :
+   Contains auxiliary files such as images, scripts, etc., which may be used during a 
+   playbook run. Includes python scripts to generate inventory file. 
+   
+#### Vagrantfile : 
+   Vagrantfile for pre-packaged linux VM bring up
+
+#### ansible.cfg : 
+   Custom ansible configuration file for openebs
+
+#### site.yml : 
+   The master playbook which executes all roles
+   
+### INSTALLATION
+
+The ansible based CI-CD framework for openebs can be installed via a git clone of the elves 
+repository (openebs/elves/ansible). 
+
+`git clone https://github.com/openebs/elves.git`
+
+The pre-requisites include availability of at-least four linux machines (VMs OR bare-metal boxes) 
+with basic development packages, SSH service & ansible (version >= 2.3) installed 
+(ansible in turn needs python-minimal on the boxes as a pre-requisite).
+
+### USAGE
+
+- Edit the machines.in in the ansible/inventory folder to reflect the correct IP addresses
+- Ensure that the env variables for the username and passwords of respective machines are set
+- Edit the all.yml to reflect the desired volume properties & network cidr for volume container
+- Trigger the ansible playbook run using command 
+
+`ansible-playbook site.yml` 
+
+The following actions are carried out upon running the playbook : 
+
+- Client machine is setup to generate inventory file
+- The inventory file (hosts) is updated with latest info from the machines.in input file
+- Maya server is setup
+- Storage hosts are setup
+- volume is created
+- Container to launch FIO is instantiated
+- Cleanup is performed post user confirmation
+
+### SWITCHES AND LATCHES
+
+- Use `-v` flag while running the playbook to enable verbose logging. 
+- Use ansible tags to run/skip tasks in the roles
+
+### CONTRIBUTIONS
+
+If you'd like to contribute, please fork the repository and use a feature branch. 
+Pull requests are warmly welcome."
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -12,7 +12,8 @@
 # some basic default values...
 
 inventory      = ./inventory/hosts
-stdout_callback = dense
+callback_plugins   = ./plugins/callback
+#stdout_callback = dense
 #library        = /usr/share/my_modules/
 #remote_tmp     = ~/.ansible/tmp
 #local_tmp      = ~/.ansible/tmp

--- a/ansible/plugins/callback/default.py
+++ b/ansible/plugins/callback/default.py
@@ -1,0 +1,292 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible import constants as C
+from ansible.plugins.callback import CallbackBase
+from ansible.utils.color import colorize, hostcolor
+
+class CallbackModule(CallbackBase):
+
+    '''
+    This is the default callback interface, which simply prints messages
+    to stdout when new callback events are received.
+    '''
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'default'
+
+    def __init__(self):
+
+        self._play = None
+        self._last_task_banner = None
+        super(CallbackModule, self).__init__()
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+
+        if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        self._handle_exception(result._result)
+        self._handle_warnings(result._result)
+
+        if result._task.loop and 'results' in result._result:
+            self._process_items(result)
+
+        else:
+            if delegated_vars:
+                self._display.display("fatal: [%s -> %s]: FAILED! => %s" % (result._host.get_name(), delegated_vars['ansible_host'], self._dump_results(result._result)), color=C.COLOR_ERROR)
+            else:
+                self._display.display("fatal: [%s]: FAILED! => %s" % (result._host.get_name(), self._dump_results(result._result)), color=C.COLOR_ERROR)
+
+        if ignore_errors:
+            self._display.display("...ignoring", color=C.COLOR_SKIP)
+
+    def v2_runner_on_ok(self, result):
+
+        if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        self._clean_results(result._result, result._task.action)
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        self._clean_results(result._result, result._task.action)
+        if result._task.action in ('include', 'include_role'):
+            return
+        elif result._result.get('changed', False):
+            if delegated_vars:
+                msg = "changed: [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+            else:
+                msg = "changed: [%s]" % result._host.get_name()
+            color = C.COLOR_CHANGED
+        else:
+            if delegated_vars:
+                msg = "ok: [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+            else:
+                msg = "ok: [%s]" % result._host.get_name()
+            color = C.COLOR_OK
+
+        self._handle_warnings(result._result)
+
+        if result._task.loop and 'results' in result._result:
+            self._process_items(result)
+        else:
+
+            if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
+                msg += " => %s" % (self._dump_results(result._result),)
+            self._display.display(msg, color=color)
+
+    def v2_runner_on_skipped(self, result):
+        if C.DISPLAY_SKIPPED_HOSTS:
+            if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:
+                self._print_task_banner(result._task)
+
+            if result._task.loop and 'results' in result._result:
+                self._process_items(result)
+            else:
+                msg = "skipping: [%s]" % result._host.get_name()
+                if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
+                    msg += " => %s" % self._dump_results(result._result)
+                self._display.display(msg, color=C.COLOR_SKIP)
+
+    def v2_runner_on_unreachable(self, result):
+        if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        if delegated_vars:
+            self._display.display("fatal: [%s -> %s]: UNREACHABLE! => %s" % (result._host.get_name(), delegated_vars['ansible_host'], self._dump_results(result._result)), color=C.COLOR_UNREACHABLE)
+        else:
+            self._display.display("fatal: [%s]: UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result)), color=C.COLOR_UNREACHABLE)
+
+    def v2_playbook_on_no_hosts_matched(self):
+        self._display.display("skipping: no hosts matched", color=C.COLOR_SKIP)
+
+    def v2_playbook_on_no_hosts_remaining(self):
+        self._display.banner("NO MORE HOSTS LEFT")
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+
+        if self._play.strategy != 'free':
+            self._print_task_banner(task)
+
+    def _print_task_banner(self, task):
+        # args can be specified as no_log in several places: in the task or in
+        # the argument spec.  We can check whether the task is no_log but the
+        # argument spec can't be because that is only run on the target
+        # machine and we haven't run it thereyet at this time.
+        #
+        # So we give people a config option to affect display of the args so
+        # that they can secure this if they feel that their stdout is insecure
+        # (shoulder surfing, logging stdout straight to a file, etc).
+        args = ''
+        if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
+            args = u', '.join(u'%s=%s' % a for a in task.args.items())
+            args = u' %s' % args
+
+        self._display.banner(u"TASK [%s%s]" % (task.get_name().strip(), args))
+        if self._display.verbosity >= 2:
+            path = task.get_path()
+            if path:
+                self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
+
+        self._last_task_banner = task._uuid
+
+    def v2_playbook_on_cleanup_task_start(self, task):
+        self._display.banner("CLEANUP TASK [%s]" % task.get_name().strip())
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self._display.banner("RUNNING HANDLER [%s]" % task.get_name().strip())
+
+    def v2_playbook_on_play_start(self, play):
+        name = play.get_name().strip()
+        if not name:
+            msg = u"PLAY"
+        else:
+            msg = u"PLAY [%s]" % name
+
+        self._play = play
+
+        self._display.banner(msg)
+
+    def v2_on_file_diff(self, result):
+        if result._task.loop and 'results' in result._result:
+            for res in result._result['results']:
+                if 'diff' in res and res['diff'] and res.get('changed', False):
+                    diff = self._get_diff(res['diff'])
+                    if diff:
+                        self._display.display(diff)
+        elif 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
+            diff = self._get_diff(result._result['diff'])
+            if diff:
+                self._display.display(diff)
+
+    def v2_runner_item_on_ok(self, result):
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        if result._task.action in ('include', 'include_role'):
+            return
+        elif result._result.get('changed', False):
+            msg = 'changed'
+            color = C.COLOR_CHANGED
+        else:
+            msg = 'ok'
+            color = C.COLOR_OK
+
+        if delegated_vars:
+            msg += ": [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+        else:
+            msg += ": [%s]" % result._host.get_name()
+
+        msg += " => (item=%s)" % (self._get_item(result._result),)
+
+        if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
+            msg += " => %s" % self._dump_results(result._result)
+        self._display.display(msg, color=color)
+
+    def v2_runner_item_on_failed(self, result):
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        self._handle_exception(result._result)
+
+        msg = "failed: "
+        if delegated_vars:
+            msg += "[%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+        else:
+            msg += "[%s]" % (result._host.get_name())
+
+        self._handle_warnings(result._result)
+        self._display.display(msg + " (item=%s) => %s" % (self._get_item(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
+
+    def v2_runner_item_on_skipped(self, result):
+        if C.DISPLAY_SKIPPED_HOSTS:
+            msg = "skipping: [%s] => (item=%s) " % (result._host.get_name(), self._get_item(result._result))
+            if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
+                msg += " => %s" % self._dump_results(result._result)
+            self._display.display(msg, color=C.COLOR_SKIP)
+
+    def v2_playbook_on_include(self, included_file):
+        msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
+        self._display.display(msg, color=C.COLOR_SKIP)
+
+    def v2_playbook_on_stats(self, stats):
+        self._display.banner("PLAY RECAP")
+
+        hosts = sorted(stats.processed.keys())
+        for h in hosts:
+            t = stats.summarize(h)
+
+            self._display.display(u"%s : %s %s %s %s" % (
+                hostcolor(h, t),
+                colorize(u'ok', t['ok'], C.COLOR_OK),
+                colorize(u'changed', t['changed'], C.COLOR_CHANGED),
+                colorize(u'unreachable', t['unreachable'], C.COLOR_UNREACHABLE),
+                colorize(u'failed', t['failures'], C.COLOR_ERROR)),
+                screen_only=True
+            )
+
+            self._display.display(u"%s : %s %s %s %s" % (
+                hostcolor(h, t, False),
+                colorize(u'ok', t['ok'], None),
+                colorize(u'changed', t['changed'], None),
+                colorize(u'unreachable', t['unreachable'], None),
+                colorize(u'failed', t['failures'], None)),
+                log_only=True
+            )
+
+        self._display.display("", screen_only=True)
+
+        # print custom stats
+        if C.SHOW_CUSTOM_STATS and stats.custom:
+            self._display.banner("CUSTOM STATS: ")
+            # per host
+            #TODO: come up with 'pretty format'
+            for k in sorted(stats.custom.keys()):
+                if k == '_run':
+                    continue
+                self._display.display('\t%s: %s' % (k, self._dump_results(stats.custom[k], indent=1).replace('\n','')))
+
+            # print per run custom stats
+            if '_run' in stats.custom:
+                self._display.display("", screen_only=True)
+                self._display.display('\tRUN: %s' % self._dump_results(stats.custom['_run'], indent=1).replace('\n',''))
+            self._display.display("", screen_only=True)
+
+    def v2_playbook_on_start(self, playbook):
+        if self._display.verbosity > 1:
+            from os.path import basename
+            self._display.banner("PLAYBOOK: %s" % basename(playbook._file_name))
+
+        if self._display.verbosity > 3:
+            if self._options is not None:
+                for option in dir(self._options):
+                    if option.startswith('_') or option in ['read_file', 'ensure_value', 'read_module']:
+                        continue
+                    val =  getattr(self._options,option)
+                    if val:
+                        self._display.vvvv('%s: %s' % (option,val))
+
+    def v2_runner_retry(self, result):
+        task_name = result.task_name or result._task
+        msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name, result._result['retries'] - result._result['attempts'])
+        if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
+            msg+= "Result was: %s" % self._dump_results(result._result)
+        self._display.v('%s' %(msg))


### PR DESCRIPTION
Added custom callback plugin to hide "FAILED-RETRYING" logs for a until-retry operation while performing a non-verbose playbook run

Code Changes:
----------------
Added custom callback plugin to hide "FAILED-RETRYING" logs for a until-retry operation while performing a non-verbose playbook run. Involved : 

* Addition of a plugins/callback folder in elves/ansible with a modified defaults.py (default callback module)
* Updating the ansible.cfg with custom callback plugin path

Tested On:
-----------

Developer Laptops - (Using Vagrant Boxes- Ubuntu)
OpenEBS Test Machine - Multi VM. - (ESX 6.0 Ubuntu VMs)

Details of code fix:
-------------------
This code fix covers readability enhancements during a playbook run