### PR TITLE
Ansible based CI framework for OpenEBS. Fixes for issue #104

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -12,7 +12,8 @@
 # some basic default values...
 
 inventory      = ./inventory/hosts
-stdout_callback = dense
+callback_plugins   = ./plugins/callback
+stdout_callback = openebs 
 #library        = /usr/share/my_modules/
 #remote_tmp     = ~/.ansible/tmp
 #local_tmp      = ~/.ansible/tmp

--- a/ansible/plugins/callback/openebs.py
+++ b/ansible/plugins/callback/openebs.py
@@ -1,0 +1,24 @@
+#Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+
+#Implementation of Custom Class that inherits the 'default' stdout_callback plugin 
+#and overrides the v2_runner_retry api for displaying the 'FAILED - RETRYING' only 
+#during verbose mode.
+class CallbackModule(CallbackModule_default):
+
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'openebs'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def v2_runner_retry(self, result):
+        task_name = result.task_name or result._task
+        msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name, result._result['retries'] - result._result['attempts'])
+        if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
+           msg+= "Result was: %s" % self._dump_results(result._result)
+        self._display.v('%s' %(msg))


### PR DESCRIPTION
Create custom callback plugin to hide "FAILED-RETRYING" logs for a until-retry operation while performing a non-verbose playbook run

Code Changes:
----------------
- Created a new plugin called 'openebs' which inherits the default plugin and overrides the v2_runner_retry() api,
  to display errors in verbose mode.
- Created a new folder called plugins/callback under elves/ansible and placed the openebs plugin in the same.
- Updated ansible.cfg to include custom path for callback_plugins (elves/ansible/plugins/callback)

Tested On:
-----------
Developer Laptops - (Using Vagrant Boxes- Ubuntu)
OpenEBS Test Machine - Multi VM. - (ESX 6.0 Ubuntu VMs)

Details of code fix:
--------------------
This code fix covers readability enhancements during a playbook run