### PR TITLE
Fix for Issue #20

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -87,10 +87,6 @@ slack_notify: true
 
 clean: true
 
-#Name of tarfile containing test images
-
-tarfile: test_images.tar
-
 #########################################
 # OpenEBS CI Specifications             #
 #########################################

--- a/ansible/load-images.yml
+++ b/ansible/load-images.yml
@@ -2,14 +2,15 @@
 - hosts: kubernetes-kubeminions
   
   tasks:
-    - name: Check for presence of tarfile
-      stat: 
-        path: "{{ playbook_dir }}/roles/load-test-images/files/{{ tarfile }}"
+    - name: Check for presence of tarfiles
+      shell: ls *.tar
+      args:
+        chdir: "{{ playbook_dir }}/roles/load-test-images/files" 
       register: tar 
       delegate_to: 127.0.0.1 
 
     - name: Execute load-test-images role if tarfile exists
       include_role:
         name: load-test-images
-      when: tar.stat.exists is defined and tar.stat.exists
+      when: tar.stdout != ""
 

--- a/ansible/roles/load-test-images/defaults/main.yml
+++ b/ansible/roles/load-test-images/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 
-tarfile: test_images.tar
-
-# Applies to non-vagrant VMs/baremetal
 tarfile_path: "{{ ansible_env.HOME}}"
+
+test_images:
+# keys -> label:image:tag
+  - {label: percona, image: percona, tag: latest}
+  - {label: jupyter, image: satyamz/docker-jupyter, tag: v0.4}
+  - {label: postgres, image: crunchydata/crunchy-postgres, tag: centos7-9.6-1.4.0}
+  - {label: mysqlclient, image: openebs/tests-mysql-client, tag: latest}
+

--- a/ansible/roles/load-test-images/tasks/main.yml
+++ b/ansible/roles/load-test-images/tasks/main.yml
@@ -1,28 +1,30 @@
 ---
-- block:
+- block: 
 
     - name: Load test images from Archive
-      command: docker load --input "{{ tarfile }}"
+      command: docker load --input "{{item.label}}_{{item.tag}}.tar"
       args:
         chdir: "/vagrant/roles/load-test-images/files"
       become: true
+      with_items: "{{test_images}}"
+ 
+  when: is_vagrant_vm  
 
-  when: is_vagrant_vm
-
-- block:
+- block: 
 
     - name: Copy test image tarfile to kubernetes hosts
       copy:
-        src: "{{ tarfile }}"
+        src: "{{item.label}}_{{item.tag}}.tar"
         dest: "{{ tarfile_path }}"
       become: true
-      when: is_vagrant_vm
+      with_items: "{{test_images}}"
 
     - name: Load test images from Archive
-      command: docker load --input "{{ tarfile }}"
+      command: docker load --input "{{item.label}}_{{item.tag}}.tar"
       args:
         chdir: "{{ tarfile_path }}"
       become: true
-
-  when: not is_vagrant_vm
+      with_items: "{{test_images}}"
+ 
+  when: not is_vagrant_vm  
 

--- a/ansible/roles/setup-test-images/defaults/main.yml
+++ b/ansible/roles/setup-test-images/defaults/main.yml
@@ -6,23 +6,8 @@ pip_local_packages:
   - 'docker-py==1.9.0'
 
 test_images:
-
-  # I/O-tool-specific images
-  
-  #- openebs/tests-fio
-  #- openebs/tests-vdbench
-  
-  # App-specific images
-  
-  - percona
-  - satyamz/docker-jupyter:v0.4
-  - crunchydata/crunchy-postgres:centos7-9.6-1.4.0
-  #- openebs/tests-mysql-master
-  #- openebs/tests-mysql-slave
-  
-  # App-load-generator images
-  
-  - openebs/tests-mysql-client 
-  #- openebs/tests-tpcc-client
-
-tarfile: test_images.tar
+# keys -> label:image:tag
+  - {label: percona, image: percona, tag: latest}
+  - {label: jupyter, image: satyamz/docker-jupyter, tag: v0.4}
+  - {label: postgres, image: crunchydata/crunchy-postgres, tag: centos7-9.6-1.4.0}
+  - {label: mysqlclient, image: openebs/tests-mysql-client, tag: latest}

--- a/ansible/roles/setup-test-images/tasks/main.yml
+++ b/ansible/roles/setup-test-images/tasks/main.yml
@@ -17,20 +17,16 @@
 
 - name: Fetch test images from dockerhub
   docker_image: 
-    name: "{{item}}"
+    name: "{{item.image}}:{{item.tag}}"
     state: present
     pull: true
     force: yes
   register: result
-  until: "'Pulled image' and item in result.actions[0]"
+  until: "'Pulled image' and item.image in result.actions[0]"
   delay: 60
   retries: 3  
   with_items: "{{ test_images }}"
   become: true
-
-- name: Print test image names
-  shell: printf "{{ item }}\n" >> imagelist.tmp
-  with_items: "{{ test_images }}"
 
 - name: Create files directory in load-test-images role
   file:
@@ -38,12 +34,15 @@
     state: directory
     mode: 0755
 
-- name: TAR the test images 
-  shell: docker save $(cat imagelist.tmp) -o {{playbook_dir}}/roles/load-test-images/files/{{ tarfile }}
+- name: Create TAR files for test images
+  shell: >
+    docker save {{item.image}}:{{item.tag}}
+    -o {{item.label}}_{{item.tag}}.tar
+  args:
+    chdir: "{{playbook_dir}}/roles/load-test-images/files"
+    creates: "{{item.label}}_{{item.tag}}.tar"
   become: true
-
-- name: Remove the .tmp file created to hold image list
-  file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+  with_items: "{{ test_images }}"
 
 - name: Get current user details
   command: whoami
@@ -59,7 +58,7 @@
 
 - name: Remove test images from localhost
   docker_image:
-    name: "{{ item }}" 
+    name: "{{item.image}}:{{item.tag}}" 
     state: absent
   with_items: "{{ test_images }}"
   become: true


### PR DESCRIPTION
Code Changes : 
-----------------

- The setup-test-images role creates separate tar file for each test image suffixed with image version
- The load-test-images role loads the images from above individual tarfiles
- Changes in logic to detect presence of image tar files in "files" folder of load-test-images role
- Reverts an additional global variable introduced in #19

Fixes #20 

Output : 
---------

```
22:52:23 TASK [Check for presence of tarfiles] ******************************************

22:52:23 task path: /var/lib/[*******]/openebs/e2e/ansible/load-images.yml:5
22:52:23 changed: [kubeminion02 -> 127.0.0.1] => {"changed": true, "cmd": "ls *.tar", "delta": "0:00:00.012725", "end": "2017-10-17 22:52:23.685181", "rc": 0, "start": "2017-10-17 22:52:23.672456", "stderr": "", "stderr_lines": [], "stdout": "jupyter_v0.4.tar\nmysqlclient_latest.tar\npercona_latest.tar\npostgres_centos7-9.6-1.4.0.tar", "stdout_lines": ["jupyter_v0.4.tar", "mysqlclient_latest.tar", "percona_latest.tar", "postgres_centos7-9.6-1.4.0.tar"]}
22:52:23 changed: [kubeminion01 -> 127.0.0.1] => {"changed": true, "cmd": "ls *.tar", "delta": "0:00:00.013118", "end": "2017-10-17 22:52:23.685862", "rc": 0, "start": "2017-10-17 22:52:23.672744", "stderr": "", "stderr_lines": [], "stdout": "jupyter_v0.4.tar\nmysqlclient_latest.tar\npercona_latest.tar\npostgres_centos7-9.6-1.4.0.tar", "stdout_lines": ["jupyter_v0.4.tar", "mysqlclient_latest.tar", "percona_latest.tar", "postgres_centos7-9.6-1.4.0.tar"]}
```

```
22:52:23 TASK [load-test-images : Load test images from Archive] ************************

22:52:23 task path: /var/lib/[*******]/openebs/e2e/ansible/roles/load-test-images/tasks/main.yml:4
22:52:52 changed: [kubeminion02] => (item={u'image': u'percona', u'tag': u'latest', u'label': u'percona'}) => {"changed": true, "cmd": ["docker", "load", "--input", "percona_latest.tar"], "delta": "0:00:28.714774", "end": "2017-10-17 17:22:50.984342", "item": {"image": "percona", "label": "percona", "tag": "latest"}, "rc": 0, "start": "2017-10-17 17:22:22.269568", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
22:52:55 changed: [kubeminion01] => (item={u'image': u'percona', u'tag': u'latest', u'label': u'percona'}) => {"changed": true, "cmd": ["docker", "load", "--input", "percona_latest.tar"], "delta": "0:00:31.361782", "end": "2017-10-17 17:22:53.516901", "item": {"image": "percona", "label": "percona", "tag": "latest"}, "rc": 0, "start": "2017-10-17 17:22:22.155119", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
22:55:33 changed: [kubeminion02] => (item={u'image': u'satyamz/docker-jupyter', u'tag': u'v0.4', u'label': u'jupyter'}) => {"changed": true, "cmd": ["docker", "load", "--input", "jupyter_v0.4.tar"], "delta": "0:02:39.689797", "end": "2017-10-17 17:25:30.993924", "item": {"image": "satyamz/docker-jupyter", "label": "jupyter", "tag": "v0.4"}, "rc": 0, "start": "2017-10-17 17:22:51.304127", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
22:55:35 changed: [kubeminion01] => (item={u'image': u'satyamz/docker-jupyter', u'tag': u'v0.4', u'label': u'jupyter'}) => {"changed": true, "cmd": ["docker", "load", "--input", "jupyter_v0.4.tar"], "delta": "0:02:39.282934", "end": "2017-10-17 17:25:33.124406", "item": {"image": "satyamz/docker-jupyter", "label": "jupyter", "tag": "v0.4"}, "rc": 0, "start": "2017-10-17 17:22:53.841472", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
22:56:27 changed: [kubeminion02] => (item={u'image': u'crunchydata/crunchy-postgres', u'tag': u'centos7-9.6-1.4.0', u'label': u'postgres'}) => {"changed": true, "cmd": ["docker", "load", "--input", "postgres_centos7-9.6-1.4.0.tar"], "delta": "0:00:53.512844", "end": "2017-10-17 17:26:25.485193", "item": {"image": "crunchydata/crunchy-postgres", "label": "postgres", "tag": "centos7-9.6-1.4.0"}, "rc": 0, "start": "2017-10-17 17:25:31.972349", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
22:56:27 changed: [kubeminion01] => (item={u'image': u'crunchydata/crunchy-postgres', u'tag': u'centos7-9.6-1.4.0', u'label': u'postgres'}) => {"changed": true, "cmd": ["docker", "load", "--input", "postgres_centos7-9.6-1.4.0.tar"], "delta": "0:00:51.848396", "end": "2017-10-17 17:26:25.526085", "item": {"image": "crunchydata/crunchy-postgres", "label": "postgres", "tag": "centos7-9.6-1.4.0"}, "rc": 0, "start": "2017-10-17 17:25:33.677689", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
22:56:35 changed: [kubeminion01] => (item={u'image': u'openebs/tests-mysql-client', u'tag': u'latest', u'label': u'mysqlclient'}) => {"changed": true, "cmd": ["docker", "load", "--input", "mysqlclient_latest.tar"], "delta": "0:00:07.571146", "end": "2017-10-17 17:26:33.352870", "item": {"image": "openebs/tests-mysql-client", "label": "mysqlclient", "tag": "latest"}, "rc": 0, "start": "2017-10-17 17:26:25.781724", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
22:56:35 changed: [kubeminion02] => (item={u'image': u'openebs/tests-mysql-client', u'tag': u'latest', u'label': u'mysqlclient'}) => {"changed": true, "cmd": ["docker", "load", "--input", "mysqlclient_latest.tar"], "delta": "0:00:07.837105", "end": "2017-10-17 17:26:33.654025", "item": {"image": "openebs/tests-mysql-client", "label": "mysqlclient", "tag": "latest"}, "rc": 0, "start": "2017-10-17 17:26:25.816920", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```