### PR TITLE
Create chaos specs in dry-run mode

### DIFF
--- a/chaos/chaoskube/chaoskube.yaml
+++ b/chaos/chaoskube/chaoskube.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: chaoskube
+  labels:
+    app: chaoskube
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: chaoskube
+    spec:
+      serviceAccountName: chaoskube
+      containers:
+      - name: chaoskube
+        image: quay.io/linki/chaoskube:v0.8.0
+        args:
+        # Provided below are possible flags to set in chaoskube.
+        # This deployment will create a vanilla chaoskube w/o policies
+        # which will be configured by a test playbook
+       
+        # kill a pod every 10 minutes
+        #- --interval=10m
+        
+        # only target pods in the test environment
+        #- --labels=openebs/controller=jiva-controller
+        
+        # only consider pods with this annotation
+        #- --annotations=chaos.alpha.kubernetes.io/enabled=true
+        
+        # exclude all pods in the kube-system namespace
+        #- --namespaces=!kube-system
+        
+        # don't kill anything on weekends
+        #- --excluded-weekdays=Sat,Sun
+        
+        # don't kill anything during the night or at lunchtime
+        #- --excluded-times-of-day=22:00-08:00,11:00-13:00
+        
+        # don't kill anything as a joke or on christmas eve
+        #- --excluded-days-of-year=Apr1,Dec24
+        
+        # let's make sure we all agree on what the above times mean
+        #- --timezone=UTC
+        
+        # terminate pods for real: this disables dry-run mode which is on by default
+        #- --no-dry-run
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaoskube
+  labels:
+    app: chaoskube

--- a/chaos/pumba/pumba_kube.yml
+++ b/chaos/pumba/pumba_kube.yml
@@ -1,0 +1,42 @@
+# If you are running Kubernetes >= 1.1.0. You can take advantage of DaemonSets to automatically deploy the Pumba on all your nodes.
+# On 1.1.x you'll need to explicitly enable the DaemonSets extension, see http://kubernetes.io/v1.1/docs/admin/daemons.html#caveats.
+
+# You'll then be able to deploy the DaemonSet with the command
+# `kubectl create -f pumba_kube.yaml`
+
+# If you are not running Kubernetes >= 1.1.0 or do not want to use DaemonSets, you can also run the Pumba as a regular docker container on each node you want to make chaos.
+# `docker run -d -v /var/run/docker.sock:/var/run/docker.sock gaiaadm/pumba pumba --random --interval 3m kill --signal SIGKILL"`
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: pumba
+spec:
+  template:
+    metadata:
+      labels:
+        app: pumba
+        com.gaiaadm.pumba: "true" # prevent pumba from killing itself
+      name: pumba
+    spec:
+      containers:
+      - image: gaiaadm/pumba:master
+        imagePullPolicy: Always
+        name: pumba
+        # Pumba command: modify it to suite your needs
+        # Dry run: Randomly try to kill some container every 3 minutes
+        command: ["pumba", "--dry", "--random", "--interval", "3m", "kill", "--signal", "SIGTERM"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 5M
+          limits:
+            cpu: 100m
+            memory: 20M
+        volumeMounts:
+          - name: dockersocket
+            mountPath: /var/run/docker.sock
+      volumes:
+        - hostPath:
+            path: /var/run/docker.sock
+          name: dockersocket


### PR DESCRIPTION
- Includes the chaoskube deployment and pumba daemonset, with the fault-injection tools operating in dry-run mode.

- The test playbooks will exec into the respective pods to induce desired fault

Signed-off-by: ksatchit <karthik.s@cloudbyte.com>