### PR TITLE
Ansible role and ansible playbook to uninstall openebs using helm chart.

### DIFF
--- a/ansible/cleanup-openebs.yml
+++ b/ansible/cleanup-openebs.yml
@@ -1,0 +1,5 @@
+
+- hosts: kubernetes-kubemasters
+  roles:
+    - {role: k8s-openebs-uninstall-helm, when: deployment_mode == "hyperconverged" and openebs_deploy == "helm"}
+

--- a/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
+++ b/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
@@ -1,0 +1,7 @@
+
+
+patch_file: update.json
+
+k8s_namespace: kube-system
+
+

--- a/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
+++ b/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
@@ -4,4 +4,4 @@ patch_file: update.json
 
 k8s_namespace: kube-system
 
-
+storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml 

--- a/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
+++ b/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
@@ -4,4 +4,6 @@ patch_file: update.json
 
 k8s_namespace: kube-system
 
-storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml 
+storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
+
+namespace: openebs 

--- a/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
+++ b/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
@@ -30,7 +30,7 @@
   args: 
     executable: /bin/bash
   register: pod
-  until: "'openebs-apiserver' and 'openebs-provisioner' not in pod.stdout"
+  until: "'apiserver' and 'provisioner' not in pod.stdout"
   delay: 60
   retries: 15
 
@@ -91,4 +91,10 @@
   file:
     path: "{{ result_kube_home.stdout }}/{{ patch_file }}"
     state: absent
+
+- name: Deleting the storage classes
+  shell: kubectl delete -f "{{ storage_classes }}"
+  args:
+    executable: /bin/bash
+  
 

--- a/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
+++ b/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
@@ -34,15 +34,6 @@
   delay: 60
   retries: 15
 
-- name: Deleting the namespace
-  shell: kubectl delete ns openebs
-  args:
-    executable: /bin/bash
-  register: ns_out
-  until: "'deleted' in ns_out.stdout"
-  delay: 20
-  retries: 10 
-
 - name: Uninstalling helm
   shell: helm reset
   args:
@@ -78,6 +69,16 @@
   until: "'deleted' in crd.stdout"
   delay: 30
   retries: 5
+
+- name: Deleting the namespace
+  shell: kubectl delete ns "{{ namespace }}"
+  args:
+    executable: /bin/bash
+  register: ns_out
+  until: "'deleted' in ns_out.stdout"
+  delay: 20
+  retries: 10
+
 
 - name: Get $HOME of K8s master for kubernetes user
   shell: source ~/.profile; echo $HOME

--- a/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
+++ b/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
@@ -26,7 +26,7 @@
   retries: 10
 
 - name: Checking if provisioner and api server are deleted.
-  shell: kubectl get po -n openebs 
+  shell: kubectl get po -n "{{ namespace }}" 
   args: 
     executable: /bin/bash
   register: pod
@@ -78,7 +78,6 @@
   until: "'deleted' in ns_out.stdout"
   delay: 20
   retries: 10
-
 
 - name: Get $HOME of K8s master for kubernetes user
   shell: source ~/.profile; echo $HOME

--- a/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
+++ b/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
@@ -1,0 +1,94 @@
+---
+
+# Steps 
+
+#1) Find out the openebs chart name.
+#2) Uninstall openebs.
+#3) Verify if openebs is uninstalled succeffully.
+#4) Delete the namespace.
+#5) Uninstall helm.
+#6) Delete the resources.
+#7) Delete the test artifacts.
+
+- name: Getting OpenEBS chart name
+  shell: helm ls --all | grep openebs | grep DEPLOYED | awk '{print $1}'
+  args:
+    executable: /bin/bash
+  register: charts
+
+- name: Uninstall OpenEBS
+  shell: helm del --purge "{{charts.stdout}}"
+  args:
+    executable: /bin/bash
+  register: purge_out
+  until: "'deleted' in purge_out.stdout"
+  delay: 60
+  retries: 10
+
+- name: Checking if provisioner and api server are deleted.
+  shell: kubectl get po -n openebs 
+  args: 
+    executable: /bin/bash
+  register: pod
+  until: "'openebs-apiserver' and 'openebs-provisioner' not in pod.stdout"
+  delay: 60
+  retries: 15
+
+- name: Deleting the namespace
+  shell: kubectl delete ns openebs
+  args:
+    executable: /bin/bash
+  register: ns_out
+  until: "'deleted' in ns_out.stdout"
+  delay: 20
+  retries: 10 
+
+- name: Uninstalling helm
+  shell: helm reset
+  args:
+    executable: /bin/bash
+  register: helm_out
+  until: "'Tiller' and 'uninstalled' in helm_out.stdout"
+  delay: 60
+  retries: 10
+
+- name: Checking if tiller has been uninstalled successfully
+  shell: kubectl get po -n "{{ k8s_namespace }}"
+  args:
+    executable: /bin/bash
+  register: pods
+  until: "'tiller-deploy' not in pods.stdout"
+  delay: 60
+  retries: 10
+
+- name: Deleting service account
+  shell: kubectl delete sa tiller -n "{{ k8s_namespace }}"
+  args:
+    executable: /bin/bash
+  register: sa
+  until: "'deleted' in sa.stdout"
+  delay: 60
+  retries: 5
+
+- name: Deleting clusterolebinding
+  shell: kubectl delete clusterrolebinding tiller
+  args:
+    executable: /bin/bash
+  register: crd
+  until: "'deleted' in crd.stdout"
+  delay: 30
+  retries: 5
+
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Deleting the patch yaml file copied to k8s master.
+  file:
+    path: "{{ result_kube_home.stdout }}/{{ patch_file }}"
+    state: absent
+


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

Implemented ansible role to uninstall openebs using helm chart and including this role in the cleanup-openebs playbook.

**Steps followed:**

- Find out the openebs chart name.
-  Uninstall openebs.
-  Verify if openebs is uninstalled successfully.
-  Delete the namespace.
-  Uninstall helm.
-  Delete the resources service account and clusterrolebinding.
-  Delete the test artifacts.

Refer the issue: https://github.com/openebs/openebs/issues/1569

**SAMPLE TEST RUN OUTPUT:**

```
giri@vagrant-host:~/openebs/e2e/ansible$ ansible-playbook cleanup-openebs.yml -vv
ansible-playbook 2.4.3.0
  config file = /home/giri/openebs/e2e/ansible/ansible.cfg
  configured module search path = [u'/home/giri/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /home/giri/openebs/e2e/ansible/ansible.cfg as config file

PLAYBOOK: cleanup-openebs.yml ******************************************************************************************************************************************
1 plays in cleanup-openebs.yml

PLAY [kubernetes-kubemasters] ******************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************
ok: [kubemaster01]
META: ran handlers

TASK [k8s-openebs-uninstall-helm : Getting OpenEBS chart name] *********************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:3
changed: [kubemaster01] => {"changed": true, "cmd": "helm ls --all | grep openebs | grep DEPLOYED | awk '{print $1}'", "delta": "0:00:01.077105", "end": "2018-05-31 16:00:32.367665", "rc": 0, "start": "2018-05-31 16:00:31.290560", "stderr": "", "stderr_lines": [], "stdout": "openebs", "stdout_lines": ["openebs"]}

TASK [k8s-openebs-uninstall-helm : Uninstall OpenEBS] ******************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:9
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "helm del --purge \"openebs\"", "delta": "0:00:11.338293", "end": "2018-05-31 16:00:44.606582", "rc": 0, "start": "2018-05-31 16:00:33.268289", "stderr": "", "stderr_lines": [], "stdout": "release \"openebs\" deleted", "stdout_lines": ["release \"openebs\" deleted"]}

TASK [k8s-openebs-uninstall-helm : Checking if provisioner and api server are deleted.] ********************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:18
FAILED - RETRYING: Checking if provisioner and api server are deleted. (15 retries left).
changed: [kubemaster01] => {"attempts": 2, "changed": true, "cmd": "kubectl get po -n openebs", "delta": "0:00:01.020544", "end": "2018-05-31 16:01:50.461093", "rc": 0, "start": "2018-05-31 16:01:49.440549", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [k8s-openebs-uninstall-helm : Deleting the namespace] *************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:27
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl delete ns openebs", "delta": "0:00:00.567794", "end": "2018-05-31 16:01:52.155611", "rc": 0, "start": "2018-05-31 16:01:51.587817", "stderr": "", "stderr_lines": [], "stdout": "namespace \"openebs\" deleted", "stdout_lines": ["namespace \"openebs\" deleted"]}

TASK [k8s-openebs-uninstall-helm : Uninstalling helm] ******************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:36
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "helm reset", "delta": "0:00:05.083432", "end": "2018-05-31 16:01:58.369972", "rc": 0, "start": "2018-05-31 16:01:53.286540", "stderr": "", "stderr_lines": [], "stdout": "Tiller (the Helm server-side component) has been uninstalled from your Kubernetes Cluster.", "stdout_lines": ["Tiller (the Helm server-side component) has been uninstalled from your Kubernetes Cluster."]}

TASK [k8s-openebs-uninstall-helm : Checking if tiller has been uninstalled successfully] *******************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:45
FAILED - RETRYING: Checking if tiller has been uninstalled successfully (10 retries left).
changed: [kubemaster01] => {"attempts": 2, "changed": true, "cmd": "kubectl get po -n \"kube-system\"", "delta": "0:00:01.054303", "end": "2018-05-31 16:03:04.569270", "rc": 0, "start": "2018-05-31 16:03:03.514967", "stderr": "", "stderr_lines": [], "stdout": "NAME                                    READY     STATUS    RESTARTS   AGE\netcd-kubemaster-01                      1/1       Running   5          1d\nkube-apiserver-kubemaster-01            1/1       Running   5          1d\nkube-controller-manager-kubemaster-01   1/1       Running   18         1d\nkube-dns-545bc4bfd4-bc67f               3/3       Running   6          1d\nkube-proxy-9fgwg                        1/1       Running   3          1d\nkube-proxy-bpg7s                        1/1       Running   26         1d\nkube-proxy-l6qtv                        1/1       Running   11         1d\nkube-proxy-rplzv                        1/1       Running   10         1d\nkube-scheduler-kubemaster-01            1/1       Running   7          1d\nkubernetes-dashboard-796487df76-2pm4m   1/1       Running   2          1d\nweave-net-p5th5                         2/2       Running   6          1d\nweave-net-p8fqh                         2/2       Running   16         1d\nweave-net-vdbw5                         2/2       Running   10         1d\nweave-net-vlw7g                         2/2       Running   4          1d", "stdout_lines": ["NAME                                    READY     STATUS    RESTARTS   AGE", "etcd-kubemaster-01                      1/1       Running   5          1d", "kube-apiserver-kubemaster-01            1/1       Running   5          1d", "kube-controller-manager-kubemaster-01   1/1       Running   18         1d", "kube-dns-545bc4bfd4-bc67f               3/3       Running   6          1d", "kube-proxy-9fgwg                        1/1       Running   3          1d", "kube-proxy-bpg7s                        1/1       Running   26         1d", "kube-proxy-l6qtv                        1/1       Running   11         1d", "kube-proxy-rplzv                        1/1       Running   10         1d", "kube-scheduler-kubemaster-01            1/1       Running   7          1d", "kubernetes-dashboard-796487df76-2pm4m   1/1       Running   2          1d", "weave-net-p5th5                         2/2       Running   6          1d", "weave-net-p8fqh                         2/2       Running   16         1d", "weave-net-vdbw5                         2/2       Running   10         1d", "weave-net-vlw7g                         2/2       Running   4          1d"]}

TASK [k8s-openebs-uninstall-helm : Deleting service account] ***********************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:54
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl delete sa tiller -n \"kube-system\"", "delta": "0:00:00.846612", "end": "2018-05-31 16:03:06.183435", "rc": 0, "start": "2018-05-31 16:03:05.336823", "stderr": "", "stderr_lines": [], "stdout": "serviceaccount \"tiller\" deleted", "stdout_lines": ["serviceaccount \"tiller\" deleted"]}

TASK [k8s-openebs-uninstall-helm : Deleting clusterolebinding] *********************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:63
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl delete clusterrolebinding tiller", "delta": "0:00:00.721009", "end": "2018-05-31 16:03:07.931464", "rc": 0, "start": "2018-05-31 16:03:07.210455", "stderr": "", "stderr_lines": [], "stdout": "clusterrolebinding \"tiller\" deleted", "stdout_lines": ["clusterrolebinding \"tiller\" deleted"]}

TASK [k8s-openebs-uninstall-helm : Get $HOME of K8s master for kubernetes user] ****************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:72
changed: [kubemaster01 -> None] => {"changed": true, "cmd": "source ~/.profile; echo $HOME", "delta": "0:00:00.016765", "end": "2018-05-31 16:03:09.007049", "rc": 0, "start": "2018-05-31 16:03:08.990284", "stderr": "", "stderr_lines": [], "stdout": "/home/ubuntu", "stdout_lines": ["/home/ubuntu"]}

TASK [k8s-openebs-uninstall-helm : Deleting the patch yaml file copied to k8s master.] *********************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:80
ok: [kubemaster01] => {"changed": false, "path": "(/home/ubuntu/update.json)", "state": "absent"}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************
kubemaster01               : ok=11   changed=9    unreachable=0    failed=0
```