### PR TITLE
Upload yaml files for cstor-pool-mgmt

### DIFF
--- a/k8s-dev/cstor-pool-mgmt/deployment-cstor-pool.yaml
+++ b/k8s-dev/cstor-pool-mgmt/deployment-cstor-pool.yaml
@@ -22,7 +22,8 @@ spec:
       containers:
       - name: cstor-pool
         # The image name here will be changed to openebs once the business logic pr is reviewed and merged in openebs/maya.
-        image: gkganeshr/cstor-pool:v1.1
+        image: openebs/cstor-pool:ci
+        imagePullPolicy: Always
         ports:
         - containerPort: 12000
           protocol: TCP
@@ -46,7 +47,8 @@ spec:
 
       - name:    cstor-pool-mgmt
         # The image name here will be changed to openebs once the business logic pr is reviewed and merged in openebs/maya.
-        image: gkganeshr/cstor-pool-mgmt:v2.3
+        image: gkganeshr/cstor-pool-mgmt:v2.7
+        imagePullPolicy: Always
         ports:
         - containerPort: 9500
           protocol: TCP
@@ -57,10 +59,12 @@ spec:
           mountPath: /dev
         - name: tmp
           mountPath: /tmp
+        - mountPath: /run/udev
+          name: udev
         env:
           # OPENEBS_IO_CSTOR_ID env has UID of cStorPool CR.
         - name: OPENEBS_IO_CSTOR_ID
-          value: "6eb3a8a5-707e-11e8-8a9f-54e1ad4a9dd4"
+          value: "ec0d620f-89c4-11e8-9b1a-54e1ad4a9dd4"      
 
       volumes:
       - name: device
@@ -73,4 +77,8 @@ spec:
         hostPath:
           # From host, dir called /var/openebs/shared-<uid> is created to avoid clash if two replicas run on same node.
           path: /var/openebs/shared-a2b
+      - name: udev
+        hostPath:
+          path: /run/udev
           type: Directory
+

--- a/k8s-dev/cstor-pool-mgmt/deployment-cstor-pool.yaml
+++ b/k8s-dev/cstor-pool-mgmt/deployment-cstor-pool.yaml
@@ -1,0 +1,72 @@
+# The deployment for cstor-pool and cstor-pool-mgmt.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cstor-pool
+  labels:
+    app: cstor-pool
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cstor-pool
+  template:
+    metadata:
+      labels:
+        app: cstor-pool
+    spec:
+      containers:
+      - name: cstor-pool
+#The image name here will be changed to openebs once the business logic pr is reviewed and merged in openebs/maya.
+        image: gkganeshr/cstor-pool:v1.1
+        ports:
+        - containerPort: 80
+        securityContext: 
+          privileged: true
+
+        volumeMounts:
+        - name: device
+          mountPath: /dev     
+        - name: tmp
+          mountPath: /tmp
+#To avoid clash between terminating and restarting pod, we keep initial delay.
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 15"]
+
+      - name:    cstor-pool-mgmt
+#The image name here will be changed to openebs once the business logic pr is reviewed and merged in openebs/maya.
+        image: gkganeshr/cstor-pool-mgmt:v1.8
+        ports:
+        - containerPort: 80
+        securityContext: 
+          privileged: true
+        volumeMounts:
+        - name: device
+          mountPath: /dev
+        - name: tmp
+          mountPath: /tmp
+        env:
+          #cstorid env has UID of cStorPool CR
+        - name: cstorid
+          value: "f774f4dd-68a8-11e8-84c7-54e1ad4a9dd4"
+#To avoid clash between terminating and restarting pod, we keep initial delay.
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 15"]
+
+      volumes:
+      - name: device
+        hostPath:
+          # directory location on host
+          path: /dev
+          # this field is optional
+          type: Directory
+      - name: tmp
+        hostPath:
+#From host, dir called /var/openebs/shared-<uid> is created to avoid clash if two replicas run on same node.
+          path: /var/openebs/shared-a2b
+          type: Directory

--- a/k8s-dev/cstor-pool-mgmt/deployment-cstor-pool.yaml
+++ b/k8s-dev/cstor-pool-mgmt/deployment-cstor-pool.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cstor-pool
+  name: cstor-pool-deploy
   labels:
     app: cstor-pool
 spec:
@@ -16,12 +16,20 @@ spec:
       labels:
         app: cstor-pool
     spec:
+      serviceAccountName: openebs-maya-operator
+        #nodeSelector:
+        #  kubernetes.io/hostname: "gke-test-default-pool-9cb32f2f-1jc1"
       containers:
       - name: cstor-pool
-#The image name here will be changed to openebs once the business logic pr is reviewed and merged in openebs/maya.
+        # The image name here will be changed to openebs once the business logic pr is reviewed and merged in openebs/maya.
         image: gkganeshr/cstor-pool:v1.1
         ports:
-        - containerPort: 80
+        - containerPort: 12000
+          protocol: TCP
+        - containerPort: 3233
+          protocol: TCP
+        - containerPort: 3232
+          protocol: TCP
         securityContext: 
           privileged: true
 
@@ -30,17 +38,18 @@ spec:
           mountPath: /dev     
         - name: tmp
           mountPath: /tmp
-#To avoid clash between terminating and restarting pod, we keep initial delay.
+          # To avoid clash between terminating and restarting pod in case older zrepl gets deleted faster, we keep initial delay.
         lifecycle:
           postStart:
-            exec:
-              command: ["/bin/sh", "-c", "sleep 15"]
+             exec:
+                command: ["/bin/sh", "-c", "sleep 2"]
 
       - name:    cstor-pool-mgmt
-#The image name here will be changed to openebs once the business logic pr is reviewed and merged in openebs/maya.
-        image: gkganeshr/cstor-pool-mgmt:v1.8
+        # The image name here will be changed to openebs once the business logic pr is reviewed and merged in openebs/maya.
+        image: gkganeshr/cstor-pool-mgmt:v2.3
         ports:
-        - containerPort: 80
+        - containerPort: 9500
+          protocol: TCP
         securityContext: 
           privileged: true
         volumeMounts:
@@ -49,14 +58,9 @@ spec:
         - name: tmp
           mountPath: /tmp
         env:
-          #cstorid env has UID of cStorPool CR
-        - name: cstorid
-          value: "f774f4dd-68a8-11e8-84c7-54e1ad4a9dd4"
-#To avoid clash between terminating and restarting pod, we keep initial delay.
-        lifecycle:
-          postStart:
-            exec:
-              command: ["/bin/sh", "-c", "sleep 15"]
+          # OPENEBS_IO_CSTOR_ID env has UID of cStorPool CR.
+        - name: OPENEBS_IO_CSTOR_ID
+          value: "6eb3a8a5-707e-11e8-8a9f-54e1ad4a9dd4"
 
       volumes:
       - name: device
@@ -67,6 +71,6 @@ spec:
           type: Directory
       - name: tmp
         hostPath:
-#From host, dir called /var/openebs/shared-<uid> is created to avoid clash if two replicas run on same node.
+          # From host, dir called /var/openebs/shared-<uid> is created to avoid clash if two replicas run on same node.
           path: /var/openebs/shared-a2b
           type: Directory

--- a/k8s-dev/cstor-pool-mgmt/openebs-operator.yaml
+++ b/k8s-dev/cstor-pool-mgmt/openebs-operator.yaml
@@ -1,0 +1,243 @@
+# Define the Service Account
+# Define the RBAC rules for the Service Account
+# Launch the maya-apiserver ( deployment )
+# Launch the maya-storagemanager ( deameon set )
+
+# Create Maya Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: default
+---
+# Define Role that allows operations on K8s pods/deployments
+#  in "default" namespace
+# TODO : change to new namespace, for isolated data network
+# TODO : the rules should be updated with required group/resources/verb
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: openebs-maya-operator
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes","nodes/proxy"]
+  verbs: ["get","list","watch","create","update"]
+- apiGroups: ["*"]
+  resources: ["namespaces","services","pods","deployments", "events", "endpoints"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["persistentvolumes","persistentvolumeclaims"]
+  verbs: ["*"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: [ "get", "list", "create" ]
+- apiGroups: ["*"]
+  resources: ["storagepools"]
+  verbs: ["get", "list"]
+- apiGroups: ["*"]
+  resources: ["cstorpools","cstorvolumereplicas","cstorvolumes"]
+  verbs: ["*"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+# Bind the Service Account with the Role Privileges.
+# TODO: Check if default account also needs to be there
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-maya-operator
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: default
+- kind: User
+  name: system:serviceaccount:default:default
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: openebs-maya-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: maya-apiserver
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: maya-apiserver
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: maya-apiserver
+        imagePullPolicy: Always
+        image: openebs/m-apiserver:0.5.4
+        ports:
+        - containerPort: 5656
+        env:
+        # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://172.28.128.3:8080"
+        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+          value: "openebs/jiva:0.5.4"
+        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+          value: "openebs/jiva:0.5.4"
+        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "openebs/m-exporter:0.5.4"
+        - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+          value: "3"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maya-apiserver-service
+spec:
+  ports:
+  - name: api
+    port: 5656
+    protocol: TCP
+    targetPort: 5656
+  selector:
+    name: maya-apiserver
+  sessionAffinity: None
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: openebs-provisioner
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: openebs-provisioner
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: openebs-provisioner
+        imagePullPolicy: Always
+        image: openebs/openebs-k8s-provisioner:0.5.4
+        env:
+        # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://10.128.0.12:8080"
+        # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_VALID_FSTYPE enables openebs provisioner to provision openebs
+        # volume other then ext4(default fstype). After adding "openebs.io/fstype"
+        # parameters in StorageClasse will provision the volume with specified fstype.
+        # This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.4 onwards
+        #- name: OPENEBS_VALID_FSTYPE
+        #  value: "ext4,xfs"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OPENEBS_MONITOR_URL
+          value: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
+        - name: OPENEBS_MONITOR_VOLKEY
+          value: "&var-OpenEBS"
+        - name: MAYA_PORTAL_URL
+          value: "https://mayaonline.io/"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepoolclaims.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepoolclaims
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepoolclaim
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePoolClaim
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - spc
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepools.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepools
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepool
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - sp
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: openebs-standard
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: volumepolicies.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: volumepolicies
+    # singular name to be used as an alias on the CLI and for display
+    singular: volumepolicy
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: VolumePolicy
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - vp

--- a/k8s-dev/cstor-pool-mgmt/pool-crd.yaml
+++ b/k8s-dev/cstor-pool-mgmt/pool-crd.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorpools.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CStorPool
+    listKind: CStorPoolList
+    plural: cstorpools
+    shortNames:
+    - cstorpool
+  scope: Cluster
+  version: v1alpha1

--- a/k8s-dev/cstor-pool-mgmt/pool-resource-cluster-1.yaml
+++ b/k8s-dev/cstor-pool-mgmt/pool-resource-cluster-1.yaml
@@ -2,20 +2,18 @@ apiVersion: openebs.io/v1alpha1
 kind: CStorPool
 metadata:
   name: pool1-abc
-  node: node-host-label
   labels:
-#The following label will be used for additional node reference, since we go for UID based selection of pod.
-    "kubernetes.io/hostname": "node-host-label"
+# The following label will be used only for additional node reference for pool, i.e., which
+# pool is located on which node.
+#    "openebs.io/hostname": "node-host-label"
 
 #finalizer helps handling deletion of resource
   finalizers: ["cstorpool.openebs.io/finalizer"]
 
 spec:
   disks:
-   diskList: ["/dev/sdc1"]
+   diskList: ["/dev/sdc","/dev/sdd"]
   poolSpec:
    cacheFile: /tmp/pool1.cache
    poolType: striped
    overProvisioning: false
-status:
-  phase: init

--- a/k8s-dev/cstor-pool-mgmt/pool-resource-cluster-1.yaml
+++ b/k8s-dev/cstor-pool-mgmt/pool-resource-cluster-1.yaml
@@ -1,0 +1,21 @@
+apiVersion: openebs.io/v1alpha1
+kind: CStorPool
+metadata:
+  name: pool1-abc
+  node: node-host-label
+  labels:
+#The following label will be used for additional node reference, since we go for UID based selection of pod.
+    "kubernetes.io/hostname": "node-host-label"
+
+#finalizer helps handling deletion of resource
+  finalizers: ["cstorpool.openebs.io/finalizer"]
+
+spec:
+  disks:
+   diskList: ["/dev/sdc1"]
+  poolSpec:
+   cacheFile: /tmp/pool1.cache
+   poolType: striped
+   overProvisioning: false
+status:
+  phase: init

--- a/k8s-dev/cstor-pool-mgmt/replica-crd.yaml
+++ b/k8s-dev/cstor-pool-mgmt/replica-crd.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorvolumereplicas.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CStorVolumeReplica
+    listKind: CStorVolumeReplicaList
+    plural: cstorvolumereplicas
+    shortNames:
+    - cvr
+  scope: Cluster
+  version: v1alpha1

--- a/k8s-dev/cstor-pool-mgmt/replica-crd.yaml
+++ b/k8s-dev/cstor-pool-mgmt/replica-crd.yaml
@@ -10,5 +10,5 @@ spec:
     plural: cstorvolumereplicas
     shortNames:
     - cvr
-  scope: Cluster
+  scope: Namespaced
   version: v1alpha1

--- a/k8s-dev/cstor-pool-mgmt/replica-resource-1.yaml
+++ b/k8s-dev/cstor-pool-mgmt/replica-resource-1.yaml
@@ -1,0 +1,25 @@
+apiVersion: openebs.io/v1alpha1
+kind: CStorVolumeReplica
+metadata:
+  name: pvc-ee171da3-07d5-11e8-a5be-42010a8001be-cstor-rep-9440ac
+  labels:
+#cstorpool uid will be used for reference and matching pool name
+   cstorpool.openebs.io/uid : c3eaf637-6a55-11e8-a958-54e1ad4a9dd4
+
+#this pool name is added as additional/alias name with zpool create command.
+   cstorpool.openebs.io/name: pool1-84eb2e
+
+#pvc name is written in cvr label for reference.
+   cstorvolumereplica.openebs.io/pvc-name: demo-vol
+
+#cstorvolume uid will be used in zfs create command as zfs volname.
+   cstorvolume.openebs.io/uid: 6a55-11e8-a958-54e1ad4a9dd4-c3eaf637
+
+#finalizer helps in handling cvr deletion.
+  finalizers: ["cstorvolumereplica.openebs.io/finalizer"]
+
+spec:
+  cStorControllerIP: 172.17.0.11
+  capacity: 10MB
+status:
+  phase: init  

--- a/k8s-dev/cstor-pool-mgmt/replica-resource-1.yaml
+++ b/k8s-dev/cstor-pool-mgmt/replica-resource-1.yaml
@@ -4,10 +4,10 @@ metadata:
   name: pvc-ee171da3-07d5-11e8-a5be-42010a8001be-cstor-rep-9440ac
   labels:
 #cstorpool uid will be used for reference and matching pool name
-   cstorpool.openebs.io/uid : c3eaf637-6a55-11e8-a958-54e1ad4a9dd4
+   cstorpool.openebs.io/uid : 6eb3a8a5-707e-11e8-8a9f-54e1ad4a9dd4
 
 #this pool name is added as additional/alias name with zpool create command.
-   cstorpool.openebs.io/name: pool1-84eb2e
+   cstorpool.openebs.io/name: pool1-abc
 
 #pvc name is written in cvr label for reference.
    cstorvolumereplica.openebs.io/pvc-name: demo-vol

--- a/k8s-dev/cstor-pool-mgmt/replica-resource-1.yaml
+++ b/k8s-dev/cstor-pool-mgmt/replica-resource-1.yaml
@@ -2,9 +2,10 @@ apiVersion: openebs.io/v1alpha1
 kind: CStorVolumeReplica
 metadata:
   name: pvc-ee171da3-07d5-11e8-a5be-42010a8001be-cstor-rep-9440ac
+  namespace: openebs
   labels:
 #cstorpool uid will be used for reference and matching pool name
-   cstorpool.openebs.io/uid : 6eb3a8a5-707e-11e8-8a9f-54e1ad4a9dd4
+   cstorpool.openebs.io/uid : ec0d620f-89c4-11e8-9b1a-54e1ad4a9dd4
 
 #this pool name is added as additional/alias name with zpool create command.
    cstorpool.openebs.io/name: pool1-abc
@@ -19,7 +20,6 @@ metadata:
   finalizers: ["cstorvolumereplica.openebs.io/finalizer"]
 
 spec:
-  cStorControllerIP: 172.17.0.11
+  targetIP: 172.17.0.11
   capacity: 10MB
-status:
-  phase: init  
+

--- a/k8s-dev/cstor-pool-mgmt/replica-resource-2.yaml
+++ b/k8s-dev/cstor-pool-mgmt/replica-resource-2.yaml
@@ -1,0 +1,14 @@
+apiVersion: openebs.io/v1alpha1
+kind: CStorVolumeReplica
+metadata:
+  name: pvc-ee171da3-07d5-11e8-a5be-42010a8001be-cstor-rep-9440ab
+  namespace: default
+  labels:
+   cstorpool.openebs.io/uid : ec0d620f-89c4-11e8-9b1a-54e1ad4a9dd4
+   cstorpool.openebs.io/name: pool1-abc
+   cstorvolumereplica.openebs.io/pvc-name: demo-vol
+   cstorvolume.openebs.io/uid: abc-vol2
+  finalizers: ["cstorvolumereplica.openebs.io/finalizer"]
+spec:
+  targetIP: 172.17.0.11
+  capacity: 10MB


### PR DESCRIPTION
Why is this change necessary ?
fixes: openebs/openebs#1539, openebs/openebs#1605

How does this change address the issue ?
The initial version of cstor-pool deployment and custom resource yaml
is updated.

How to verify this change ?
Make sure /var/openebs/shared-<uid> dir is present in deploy yaml.
kubectl apply -f pool-resource-cluster-1.yaml(with init status)
Get UID of the corresponding pool
Make sure the same UID is passed as env variable to deployment yaml.
Make sure the disk specified on CR is present
kubectl apply -f deployment-cstor-pool.yaml
To verify,
kubectl logs cstor-pool-deploy- -c cstor-pool-mgmt
Can also verify by kubectl exec into pod,
Check status of CR if it is online for successful pool creation,
offline for failure.
To delete,
kubectl delete -f pool-resource-cluster-1.yaml
If successful deletion,
CR is deleted, Can also verify from zpool status by kubectl exec into pod
If deletion is failed,
cstorpool Status field shows deletion-failed.

kubectl apply -f replica-resource-1.yaml (specifying UID from cstorvolume CR)
Check pod logs and kubectl describe cvr <cvrname>
Also verify status.

Special notes for your reviewer: The image name here will be changed to openebs once the business logic pr is raised, reviewed and merged in openebs/maya.
Status should always be init to create pool.
This is developed and verified on minikube and gke environment.
Start k8s cluster like this,

Reference: https://docs.google.com/document/d/1Q5W3uHktHa-vOm8oGp-3kpAQ3V1tvyk5AYmxxtf57Rg/edit?usp=sharing

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>