### PR TITLE
Updates to the percona liveness checks

### DIFF
--- a/e2e/percona-liveness/data-consistency/sql-test.sh
+++ b/e2e/percona-liveness/data-consistency/sql-test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+DB_PREFIX="Inventory"
+DB_SUFFIX=`echo $(mktemp) | cut -d '.' -f 2`
+DB_NAME="${DB_PREFIX}-${DB_SUFFIX}"
+
 echo -e "\nWaiting for mysql server to start accepting connections.."
 retries=10;wait_retry=30
 for i in `seq 1 $retries`; do
@@ -15,9 +19,9 @@ then
   exit 1
 fi
 
-mysql -uroot -pk8sDem0 -e "CREATE DATABASE Inventory;"
-mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" Inventory
-mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" Inventory
-mysql -uroot -pk8sDem0 -e "UPDATE Hardware SET description ="master" WHERE id = 1;" Inventory
-mysql -uroot -pk8sDem0 -e "SELECT * FROM Hardware;" Inventory
-mysql -uroot -pk8sDem0 -e "DROP DATABASE Inventory;"
+mysql -uroot -pk8sDem0 -e "CREATE DATABASE $DB_NAME;"
+mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" $DB_NAME
+mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" $DB_NAME
+mysql -uroot -pk8sDem0 -e "UPDATE Hardware SET description ="master" WHERE id = 1;" $DB_NAME
+mysql -uroot -pk8sDem0 -e "SELECT * FROM Hardware;" $DB_NAME
+mysql -uroot -pk8sDem0 -e "DROP DATABASE $DB_NAME;"

--- a/e2e/percona-liveness/data-consistency/sql-test.sh
+++ b/e2e/percona-liveness/data-consistency/sql-test.sh
@@ -2,7 +2,7 @@
 
 DB_PREFIX="Inventory"
 DB_SUFFIX=`echo $(mktemp) | cut -d '.' -f 2`
-DB_NAME="${DB_PREFIX}-${DB_SUFFIX}"
+DB_NAME="${DB_PREFIX}_${DB_SUFFIX}"
 
 echo -e "\nWaiting for mysql server to start accepting connections.."
 retries=10;wait_retry=30

--- a/e2e/percona-liveness/sql-test.sh
+++ b/e2e/percona-liveness/sql-test.sh
@@ -2,7 +2,7 @@
 
 DB_PREFIX="Inventory"
 DB_SUFFIX=`echo $(mktemp) | cut -d '.' -f 2`
-DB_NAME="${DB_PREFIX}-${DB_SUFFIX}"
+DB_NAME="${DB_PREFIX}_${DB_SUFFIX}"
 
 
 echo -e "\nWaiting for mysql server to start accepting connections.."

--- a/e2e/percona-liveness/sql-test.sh
+++ b/e2e/percona-liveness/sql-test.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+DB_PREFIX="Inventory"
+DB_SUFFIX=`echo $(mktemp) | cut -d '.' -f 2`
+DB_NAME="${DB_PREFIX}-${DB_SUFFIX}"
+
+
 echo -e "\nWaiting for mysql server to start accepting connections.."
 retries=10;wait_retry=30
 for i in `seq 1 $retries`; do
@@ -13,7 +19,7 @@ then
   echo -e "\nFailed to connect to db server after trying for $(($retries * $wait_retry))s, exiting\n"
   exit 1
 fi
-mysql -uroot -pk8sDem0 -e "CREATE DATABASE Inventory;"
-mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" Inventory
-mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" Inventory
-mysql -uroot -pk8sDem0 -e "DROP DATABASE Inventory;"
+mysql -uroot -pk8sDem0 -e "CREATE DATABASE $DB_NAME;"
+mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" $DB_NAME
+mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" $DB_NAME
+mysql -uroot -pk8sDem0 -e "DROP DATABASE $DB_NAME;"


### PR DESCRIPTION
- Included a random/auto-generated hash as a suffix to the DB name to take care of corner cases where probe failure happens after creating a database, but before dropping it (which may lead to subsequent probe failures due to existing database) 

