### PR TITLE
Upgrade cstor pool using castemplate

### DIFF
--- a/castemplate/README.md
+++ b/castemplate/README.md
@@ -1,0 +1,46 @@
+Upgrade of cstor pool has following steps -<br>
+```
+1. Patch CSP cr.
+2. Patch SP cr.
+3. Patch pool deployment.
+4. Wait for patch status.
+5. Delete older replicaset of Pool deploymnet.
+6. Perform post upgrade activity.(exec into pool pod and run some command).
+```
+These are the runtask to upgrade cstor pool- <br>
+```
+1. task-getcspdeploy (this task provides pool name, namespace, claimname)
+2. task-getcspcr (this task provides csp uuid)
+3. task-patchcsp (this runtask patches csp cr)
+4. task-patchsp (this runtask patches sp cr)
+5. task-listrs (this runtask lists older replicaset of that pool deploymnet)
+6. task-patchcspdeploy (this runtask patches pool deployment)
+7. task-deleters (this runtask deletes older replicaset for that pool deployment)
+8. task-postupgradejob (this runtask performs some post upgrde task)
+```
+Upgrade stape -
+
+1. list out all spc `kubectl get spc`
+2. form that spc list out pool deployments,csp,sp
+```
+kubectl get deploy -n opnenes -l app=cstor-pool,openebs.io/storage-pool-claim=<claim name>
+kubectl get sp , csp -l openebs.io/storage-pool-claim=<claim name>
+```
+3. select one pool and update it's name in `task-getcspdeploy` runtask.
+In step 1 castemplate task's will be-
+```
+    tasks:
+    - task-getcspdeploy
+    - task-getcspcr
+    - task-patchcsp
+    - task-patchsp
+    - task-listrs
+    - task-patchcspdeploy
+    - task-deleters
+```
+In step 2 (when new pods are in running state) castemplate task's will be-
+```
+    tasks:
+    - task-getcspdeploy
+    - task-postupgradejob
+```

--- a/castemplate/devsetup/castemplate-crd.yaml
+++ b/castemplate/devsetup/castemplate-crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: castemplates.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CASTemplate
+    listKind: CASTemplateList
+    plural: castemplates
+    shortNames:
+    - cast
+    singular: castemplate
+  scope: Cluster
+  version: v1alpha1

--- a/castemplate/devsetup/cluster-role-binding.yaml
+++ b/castemplate/devsetup/cluster-role-binding.yaml
@@ -1,0 +1,36 @@
+# service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: super-admin
+  namespace: default
+
+---
+#  cluster role
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: super-admin
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+# cluster role binding
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: super-admin
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: super-admin
+  namespace: default
+- kind: User
+  name: system:serviceaccount:default:default
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: super-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/castemplate/devsetup/main.go
+++ b/castemplate/devsetup/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/maya/pkg/client/k8s"
+	"github.com/openebs/maya/pkg/engine"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type testEngine struct {
+	engine        engine.Interface
+	defaultConfig []v1alpha1.Config
+	openebsConfig []v1alpha1.Config
+}
+
+func main() {
+	newK8sClient, err := k8s.NewK8sClient("")
+	if err != nil {
+		fmt.Println("error in getting clientset")
+		fmt.Println(err)
+		return
+	}
+
+	key := "demo-template"
+	cast, err := newK8sClient.GetOEV1alpha1CAST(key, metav1.GetOptions{})
+	if err != nil {
+		fmt.Println("error in getting cas template")
+		fmt.Println(err)
+	}
+	engine, err := engine.New(
+		cast,
+		key,
+		map[string]interface{}{},
+	)
+	if err != nil {
+		fmt.Println("error in creating machine")
+		fmt.Println(err)
+		return
+	}
+
+	data, err := engine.Run()
+	if err != nil {
+		fmt.Println("error in executing machine")
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(string(data))
+}

--- a/castemplate/devsetup/runtask-crd.yaml
+++ b/castemplate/devsetup/runtask-crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: runtasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: RunTask
+    listKind: RunTaskList
+    plural: runtasks
+    shortNames:
+    - rtask
+    singular: runtask
+  scope: Namespaced
+  version: v1alpha1

--- a/castemplate/devsetup/template.yaml
+++ b/castemplate/devsetup/template.yaml
@@ -1,0 +1,15 @@
+apiVersion: openebs.io/v1alpha1
+kind: CASTemplate
+metadata:
+  name: demo-template
+spec:
+  run:
+    tasks:
+    - task-getcspdeploy
+    - task-getcspcr
+    - task-listrs
+    - task-patchcspdeploy
+    - task-deleters
+    - task-patchcsp
+    - task-patchsp
+  taskNamespace: default

--- a/castemplate/devsetup/ubuntu-pod.yaml
+++ b/castemplate/devsetup/ubuntu-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu
+spec:
+  serviceAccountName: super-admin
+  containers:
+  - name: ubuntu
+    image: ubuntu:latest
+    # spin & wait forever
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 30; done;" ]

--- a/castemplate/post-upgrade-task/Dockerfile
+++ b/castemplate/post-upgrade-task/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:18.04
+
+COPY kubectl /usr/local/bin/kubectl
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/castemplate/post-upgrade-task/entrypoint.sh
+++ b/castemplate/post-upgrade-task/entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -ex
+
+if [ -z "$ns" ]; then
+    echo "ERROR: namespace not present"
+    exit 1
+fi
+
+if [ -z "$spc" ]; then
+    echo "ERROR: namespace not present"
+    exit 1
+fi
+
+if [ -z "$csp" ]; then
+    echo "ERROR: namespace not present"
+    exit 1
+fi
+
+pool_rs=$(kubectl get replicaset -n $ns \
+    -l app=cstor-pool,openebs.io/storage-pool-claim=$spc \
+    -o jsonpath="{range .items[?(@.metadata.ownerReferences[0].name== '$csp')]}{@.metadata.name}{end}")
+
+if [ -z "$pool_rs" ]; then
+    echo "unable to find pool replicaset"
+    exit 1
+fi
+
+pool_pod=$(kubectl get pod -n $ns\
+    -l app=cstor-pool,openebs.io/storage-pool-claim=$spc \
+    -o jsonpath="{range .items[?(@.metadata.ownerReferences[0].name== '$pool_rs')]}{@.metadata.name} {end}")
+
+if [ -z "$pool_pod" ]; then
+    echo "unable to find pool pod"
+    exit 1
+fi
+
+pool_name=""
+cstor_uid=""
+cstor_uid=$(kubectl get pod $pool_pod -n $ns \
+    -o jsonpath="{.spec.containers[*].env[?(@.name=='OPENEBS_IO_CSTOR_ID')].value}" | awk '{print $1}')
+pool_name="cstor-$cstor_uid"
+quorum_set=$(kubectl exec $pool_pod -n $ns -c cstor-pool-mgmt -- zfs set quorum=on $pool_name)
+rc=$?
+if [[ ($rc -ne 0) ]]; then
+    echo "Error: failed to set quorum for pool $pool_name"
+    exit 1
+fi
+output=$(kubectl exec $pool_pod -n $ns -c cstor-pool-mgmt -- zfs get quorum)
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "ERROR: while executing zfs get quorum for pool $pool_name, error: $rc"
+    exit 1
+fi
+no_of_non_quorum_vol=$(echo $output | grep -wo off | wc -l)
+if [ $no_of_non_quorum_vol -ne 0 ]; then
+    echo "Few($no_of_non_quorum_vol) of quorum values are having inappropriate values for quorum"
+    exit 1
+fi
+

--- a/castemplate/runtasks/task-deleters.yaml
+++ b/castemplate/runtasks/task-deleters.yaml
@@ -1,0 +1,19 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-deleters
+  namespace: default
+spec:
+  meta: |
+    {{- $rslist := .TaskResult.rslist | default "" | splitList " " -}}
+    {{- $namespace := .TaskResult.namespace | default "" -}}
+    id: deleters
+    apiVersion: extensions/v1beta1
+    kind: ReplicaSet
+    action: delete
+    runNamespace: {{ $namespace }}
+    repeatWith:
+      metas:
+      {{- range $k, $rs := $rslist }}
+      - objectName: {{ $rs }}
+      {{- end }}

--- a/castemplate/runtasks/task-getcspcr.yaml
+++ b/castemplate/runtasks/task-getcspcr.yaml
@@ -1,0 +1,15 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-getcspcr
+  namespace: default
+spec:
+  meta: |
+    {{- $name := .TaskResult.deploymentname | default "" -}}
+    id: getcspcr
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorPool
+    action: get
+    objectName: {{ $name }}
+  post: |-
+    '{{- jsonpath .JsonResult "{.metadata.uid}" | trim | saveAs "cspuid" .TaskResult | noop -}}'

--- a/castemplate/runtasks/task-getcspdeploy.yaml
+++ b/castemplate/runtasks/task-getcspdeploy.yaml
@@ -1,0 +1,17 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-getcspdeploy
+  namespace: default
+spec:
+  meta: |
+    id: getcspdeployment
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: get
+    objectName: cstor-sparse-pool-4ylk #TODO update it runtime
+    runNamespace: openebs #TODO update it runtime
+  post: |-
+    {{- jsonpath .JsonResult "{.metadata.name}" | trim | saveAs "deploymentname" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.metadata.namespace}" | trim | saveAs "namespace" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.metadata.labels.openebs\\.io/storage-pool-claim}" | trim | saveAs "poolclaim" .TaskResult | noop -}}

--- a/castemplate/runtasks/task-listrs.yaml
+++ b/castemplate/runtasks/task-listrs.yaml
@@ -1,0 +1,19 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-listrs
+  namespace: default
+spec:
+  meta: |
+    {{- $namespace := .TaskResult.namespace | default "" -}}
+    {{- $poolclaim := .TaskResult.poolclaim | default "" -}}
+    id: listrs
+    apiVersion: extensions/v1beta1
+    kind: ReplicaSet
+    action: list
+    runNamespace: {{ $namespace }}
+    options: |-
+      labelSelector: app=cstor-pool,openebs.io/storage-pool-claim={{ $poolclaim }}
+  post: |
+    {{- $name := .TaskResult.deploymentname | default "" -}}
+    {{- jsonpath .JsonResult "{range .items[?(@.metadata.ownerReferences[0].name== 'cstor-sparse-pool-4ylk')]}{@.metadata.name} {end}" | trim | saveAs "rslist" .TaskResult | noop -}}

--- a/castemplate/runtasks/task-patchcspdeploy.yaml
+++ b/castemplate/runtasks/task-patchcspdeploy.yaml
@@ -1,0 +1,44 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-patchcspdeploy
+  namespace: default
+spec:
+  meta: |
+    {{- $name := .TaskResult.deploymentname | default "" -}}
+    {{- $namespace := .TaskResult.namespace | default "" -}}
+    id: patchpatchcspdeploy
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: patch
+    objectName: {{ $name }}
+    runNamespace: {{ $namespace }}
+  task: |-
+    {{- $cspuid := .TaskResult.cspuid | default "" -}}
+    type: strategic
+    pspec: |-
+      metadata:
+        labels:
+          openebs.io/version: 0.8.1
+      spec:
+        template:
+          spec:
+            containers:
+            - name: cstor-pool
+              image: quay.io/openebs/cstor-pool:0.8.1
+              env:
+              - name: OPENEBS_IO_CSTOR_ID
+                value: {{ $cspuid }}
+              livenessProbe:
+                exec:
+                  command:
+                  - "/bin/sh"
+                  - "-c"
+                  - zfs set io.openebs:livenesstimestap='$(date)' cstor-$OPENEBS_IO_CSTOR_ID
+                failureThreshold: 3
+                initialDelaySeconds: 300
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 30
+            - name: cstor-pool-mgmt
+              image: quay.io/openebs/cstor-pool-mgmt:0.8.1

--- a/castemplate/runtasks/task-pathchcsp.yaml
+++ b/castemplate/runtasks/task-pathchcsp.yaml
@@ -1,0 +1,19 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-patchcsp
+  namespace: default
+spec:
+  meta: |
+    {{- $name := .TaskResult.deploymentname | default "" -}}
+    id: patchcsp
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorPool
+    action: patch
+    objectName: {{ $name }}
+  task: |-
+    type: merge
+    pspec: |-
+      metadata:
+        labels:
+          openebs.io/version: 0.8.1

--- a/castemplate/runtasks/task-pathchsp.yaml
+++ b/castemplate/runtasks/task-pathchsp.yaml
@@ -1,0 +1,19 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-patchsp
+  namespace: default
+spec:
+  meta: |
+    {{- $name := .TaskResult.deploymentname | default "" -}}
+    id: patchsp
+    apiVersion: openebs.io/v1alpha1
+    kind: StoragePool
+    action: patch
+    objectName: {{ $name }}
+  task: |-
+    type: merge
+    pspec: |-
+      metadata:
+        labels:
+          openebs.io/version: 0.8.1

--- a/castemplate/runtasks/task-postupgradejob.yaml
+++ b/castemplate/runtasks/task-postupgradejob.yaml
@@ -1,0 +1,37 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-postupgradejob
+  namespace: default
+spec:
+  meta: |
+    id: postupgradejob
+    apiVersion: batch/v1
+    runNamespace: default
+    kind: Job
+    action: put
+  post: '{{- "pool-post-upgrade" | addTo "postupgradejob.objectName" .TaskResult |
+    noop -}}'
+  task: |-
+    {{- $pooldeploymentname := .TaskResult.deploymentname | default "" -}}
+    {{- $namespace := .TaskResult.namespace | default "" -}}
+    {{- $poolclaim := .TaskResult.poolclaim | default "" -}}
+    apiVersion: batch/v1
+    Kind: Job
+    metadata:
+      name: pool-post-upgrade{{randAlphaNum 4 |lower }}
+    spec:
+      template:
+        spec:
+          containers:
+          - name: pool-post-upgrade
+            image: shovan1995/poolpostpatch:3
+            command: ["entrypoint.sh"]
+            env:
+            - name: ns
+              value: {{ $namespace }}
+            - name: spc
+              value: {{ $poolclaim }}
+            - name: csp
+              value: {{ $pooldeploymentname }}
+          restartPolicy: Never

--- a/castemplate/runtasks/task-waitforpatchstatus.yaml
+++ b/castemplate/runtasks/task-waitforpatchstatus.yaml
@@ -1,0 +1,46 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: task-waitforpatchstatus
+  namespace: default
+spec:
+  meta: |
+    {{- $name := .TaskResult.deploymentname | default "" -}}
+    id: waitforpatchstatus
+    runNamespace: openebs
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: get
+    objectName: {{ $name }}
+    retry: "20,120s"
+  post: |
+    {{- $replicas := .TaskResult.replicacount | default "" -}}
+    {{- $updatedReplicas := .TaskResult.updatedReplicacount | default "" -}}
+    {{- $readyReplicas := .TaskResult.readyReplicacount | default "" -}}
+    {{- $availableReplicas := .TaskResult.availableReplicacount | default "" -}}
+    {{- "" | saveAs "verifyErr" .TaskResult | noop -}}
+    {{- if eq $replicas "" }}
+    {{- "replica count not  present" | saveAs "waitforpatchstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if eq $updatedReplicas "" }}
+    {{- "updated replica count not  present" | saveAs "waitforpatchstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if eq $readyReplicas "" }}
+    {{- "ready replica count not  present" | saveAs "waitforpatchstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if eq $availableReplicas "" }}
+    {{- "available replica count not  present" | saveAs "waitforpatchstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if ne $replicas $updatedReplicas }}
+    {{- "replica count is not equal with updated replica count" | saveAs "waitforpatchstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if ne $replicas $readyReplicas }}
+    {{- "replica count is not equal with ready replica count" | saveAs "waitforpatchstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if ne $replicas $availableReplicas }}
+    {{- "replica count is not equal with available replica count" | saveAs "waitforpatchstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- jsonpath .JsonResult "{.status.replicas}" | trim | saveAs "replicacount" .TaskResult | default "" noop -}}
+    {{- jsonpath .JsonResult "{.status.updatedReplicas}" | trim | saveAs "updatedReplicacount" .TaskResult | default "" noop -}}
+    {{- jsonpath .JsonResult "{.status.readyReplicas}" | trim | saveAs "readyReplicacount" .TaskResult | default "" noop -}}
+    {{- jsonpath .JsonResult "{.status.availableReplicas}" | trim | saveAs "availableReplicacount" .TaskResult | default "" noop -}}


### PR DESCRIPTION
This PR contains runtasks to upgrade cstor pool from 0.8.0 to 0.8.1.

To test this you need to create a util binary that can execute one castemplate. main.go contains a small code that can run one castemplate. You can do `dep init` and `dep ensure` and build your binary but most of of the task support are not available yet for that I have added one sample binary that can execute a castemplate. Template name must be `demo-temlate`. You can create a ubuntu pod and copy this binary inside that pod and run it. You can bring up a testing setup by using yamls and code inside
`cast-template/devsetup` folder.

Apply all runtasks present inside `cast-template/runtasks` folder. You can get pools name from pool claim. Using these runtask you can upgrade cstor pool one by one. In every step you need to update pool name claim name and namespace. More details available in readme section.

Signed-off-by: Shovan Maity <shovan.cse91@gmail.com>