### PR TITLE
Add cas-templates for upgrading cstor volumes from 0.8.0 to 0.8.1

### DIFF
--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/README.md
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/README.md
@@ -1,0 +1,83 @@
+# Cstor Volume Upgrade Using CAS-Template (0.8.0 -> 0.8.1)
+
+After Cstor pool upgrade, now we will upgrade the volume from version 0.8.0 to 0.8.1.
+
+Steps we will be going through for upgrading a volume are  -
+
+(Note: We are using CAS-Templates for various upgrade steps (every upgrade step will be a runtask))
+
+1. Get CASType, storage class name and storage class namespace for volume given (For now, this
+   cas-template is for upgrading cstor volumes only).
+
+cas_type=`kubectl get pv $pv -o jsonpath="{.metadata.annotations.openebs\.io/cas-type}"`
+=> cstor
+
+sc_ns=`kubectl get pv pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4 -o jsonpath="{.spec.claimRef.namespace}"`
+=> default
+
+sc_name=`kubectl get pv pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4 -o jsonpath="{.spec.storageClassName}"`
+=> openebs-cstor-disk
+
+- RunTask being used (get-vol-info)
+
+2. Get resource version for the storage class being used by volume.
+
+sc_res_ver=`kubectl get sc openebs-cstor-disk -n default -o jsonpath="{.metadata.resourceVersion}"`
+=> 4102481
+
+- RunTask being used (get-sc-res-version)
+
+3. Get target-deployment, target-svc, cstor_volumes, cstor_volume_replicas(cvr), target_old_rs..
+
+### STEP: Generate deploy, replicaset and container names from PV
+#### NOTES: Ex: If PV="pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4"
+####  then c-dep: pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4-target
+
+c_dep=$(kubectl get deploy -n openebs -l openebs.io/persistent-volume=pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4,openebs.io/target=cstor-target -o jsonpath="{.items[*].metadata.name}")
+=> pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4-target
+
+- RunTask being used (list-ctrl-deployment)
+
+c_svc=$(kubectl get svc -n openebs -l openebs.io/persistent-volume=pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4,openebs.io/target-service=cstor-target-svc -o jsonpath="{.items[*].metadata.name}")
+=> pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4
+
+- RunTask being used (list-ctrl-svc)
+
+c_vol=$(kubectl get cstorvolumes -l openebs.io/persistent-volume=pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4 -n openebs -o jsonpath="{.items[*].metadata.name}")
+=> pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4
+
+- RunTask being used (list-cstor-volumes-cr)
+
+c_replicas=$(kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4 -o jsonpath="{range .items[*]}{@.metadata.name};{end}" | tr ";" "\n")
+=> pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4-demo-cstor-pool-cc9d
+=> pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4-demo-cstor-pool-ssa7
+=> pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4-demo-cstor-pool-zyq5
+
+- RunTask being used (list-cstor-volume-replicas)
+
+### Fetch the older target and replica - ReplicaSet objects which need to be deleted before upgrading. 
+### If not deleted, the new pods will be stuck in creating state - due to affinity rules.
+
+c_rs=$(kubectl get rs -n openebs -o name -l openebs.io/persistent-volume=pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4 | cut -d '/' -f 2)
+=> pvc-04a7fec6-3a6b-11e9-a409-42010a8002d4-target-799f577f68
+
+- RunTask being used (list-target-old-rs)
+
+4. Patch volume target (deployment) strategy to "Recreate".
+    - RunTask being used (patch-deployment-recreate-strategy).
+
+5. Patch volume target deployment with the changes for 0.8.1 version i.e. container images, annotations,
+   labels, etc.
+    - RunTask being used (patch-target-deployment)
+
+6. Delete old replicaset for target deployment.
+    - RunTask being used (delete-target-old-replicaset)
+
+7. Patch target svc
+    - RunTask being used (patch-target-svc)
+
+8. Patch Cstor volume CR
+    - RunTask being used (patch-cstor-volume-cr)
+
+9.  Patch Cstor Volume replicas
+    - RunTask being used (patch-cstor-volume-replica)

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/castemplate-crd.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/castemplate-crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: castemplates.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CASTemplate
+    listKind: CASTemplateList
+    plural: castemplates
+    shortNames:
+    - cast
+    singular: castemplate
+  scope: Cluster
+  version: v1alpha1

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/demo-template.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/demo-template.yaml
@@ -1,0 +1,29 @@
+apiVersion: openebs.io/v1alpha1
+kind: CASTemplate
+metadata:
+  name: demo-vol-template
+spec:
+  defaultConfig:
+  - name: pvName
+    value: "pvc-7e7e3a07-3f31-11e9-9a4c-42010a800058" # name of the volume to be upgraded
+  - name: namespace
+    value: "openebs"
+  - name: targetVersion
+    value: "0.8.1"
+  run:
+    tasks:
+    - get-vol-info
+    - get-sc-res-version
+    - list-ctrl-deployment
+    - list-ctrl-svc
+    - list-cstor-volumes-cr
+    - list-cstor-volume-replicas
+    - list-target-old-rs
+    - patch-deployment-recreate-strategy
+    - patch-target-deployment
+    - deploy-rollout-status
+    - delete-target-old-replicaset
+    - patch-target-svc
+    - patch-cstor-volume-cr
+    - patch-cstor-volume-replica
+  taskNamespace: default

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/latest-cstor-volume-upgrade.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/latest-cstor-volume-upgrade.yaml
@@ -1,0 +1,759 @@
+# Sample runtasks for upgrading a cstor volume
+
+# CASTemplate cstor-volume-update-080-081 is
+# used to upgrade a cstor volume
+apiVersion: openebs.io/v1alpha1
+kind: CASTemplate
+metadata:
+  name: cstor-volume-update-080-081
+spec:
+  defaultConfig:
+  - name: baseversion
+    value: "0.8.0"
+  - name: targetversion
+    value: "0.8.1"
+  - name: successStatus
+    value: "Success"
+  - name: failStatus
+    value: "Fail"
+  run:
+    tasks:
+    - upgrade-cstor-volume-080-081-patch-upgrade-result
+#    - upgrade-cstor-volume-080-081-get-vol-details
+#    - upgrade-cstor-volume-080-081-get-sc-res-version
+#    - upgrade-cstor-volume-080-081-list-target-deployment
+#    - upgrade-cstor-volume-080-081-list-target-svc
+#    - upgrade-cstor-volume-080-081-list-cstorvolumecr
+#    - upgrade-cstor-volume-080-081-list-cstorvolumereplicas
+#    - upgrade-cstor-volume-080-081-list-target-old-rs
+#    - upgrade-cstor-volume-080-081-pre-check-deployment-rollout-status-strategy
+#    - upgrade-cstor-volume-080-081-patch-deployment-strategy
+#    - upgrade-cstor-volume-080-081-post-check-deployment-rollout-status-strategy
+#    - upgrade-cstor-volume-080-081-post-check-deployment-strategy-patch
+#    - upgrade-cstor-volume-080-081-patch-target-deployment-latest-versions
+#    - upgrade-cstor-volume-080-081-post-check-deployment-rollout-status-latest-versions
+#    - upgrade-cstor-volume-080-081-post-check-patch-deployment-image
+#    - upgrade-cstor-volume-080-081-patch-target-svc
+#    - upgrade-cstor-volume-080-081-post-check-target-svc
+#    - upgrade-cstor-volume-080-081-patch-cstor-volume-cr
+#    - upgrade-cstor-volume-080-081-post-check-cstor-volume-cr
+#    - upgrade-cstor-volume-080-081-patch-cstor-volume-replica
+#    - upgrade-cstor-volume-080-081-post-check-cstor-volume-replicas
+#    - upgrade-cstor-volume-080-081-delete-target-old-replicaset
+  taskNamespace: default
+
+---
+
+# This runtask will patch the upgrade result CR
+# with the basic details such as name, namespace and kind
+
+#This runtask has been updated with the latest way of updating
+# an upgrade result CR
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-patch-upgrade-result
+  namespace: default
+spec:
+  meta: |
+    id: patchResult
+    apiVersion: openebs.io/v1alpha1
+    kind: UpgradeResult
+    action: patch
+    objectName: {{ .UpgradeItem.upgradeResultName }}
+    runNamespace: default
+  post: |
+    {{ $retries := 0 -}}
+    {{- $message := printf "upgradeResult {%s} has been patched with basic details such as name and namespace of the resource to be upgraded." .UpgradeItem.upgradeResultName -}}
+    {{- $URName := upgradeResultWithTaskOwnerName .UpgradeItem.upgradeResultName -}}
+    {{- $URNamespace := upgradeResultWithTaskOwnerNamespace "default" -}}
+    {{- $taskName := upgradeResultWithTaskName "upgrade-cstor-volume-080-081-patch-upgrade-result" -}}
+    {{- $taskStatus := upgradeResultWithTaskStatus "successful" -}}
+    {{- $taskMessage := upgradeResultWithTaskMessage $message -}}
+    {{- $taskStartTime := upgradeResultWithTaskStartTime now -}}
+    {{- $taskEndTime := upgradeResultWithTaskEndTime now -}}
+    {{- $taskRetries := upgradeResultWithTaskRetries 7 -}}
+    {{- upgradeResultUpdateTasks $taskStartTime $taskRetries $URName $URNamespace $taskName $taskStatus $taskMessage $taskEndTime -}}
+  task: |-
+    type: merge
+    pspec: |-
+      status:
+        resource:
+          name: {{ .UpgradeItem.name }}
+          namespace: {{ .UpgradeItem.namespace }}
+          kind: {{ .UpgradeItem.kind }}
+
+---
+
+# get volume details
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-get-vol-details
+  namespace: default
+spec:
+  meta: |
+    id: getvoldetails
+    apiVersion: v1
+    kind: PersistentVolume
+    action: get
+    objectName: {{ .UpgradeItem.name }}
+    runNamespace: {{ .UpgradeItem.namespace }}
+  post: |
+    {{- jsonpath .JsonResult "{.metadata.annotations.openebs\\.io/cas-type}" | trim | saveAs "getvoldetails.volCASType" .TaskResult | noop -}}
+    {{- .TaskResult.getvoldetails.volCASType | notFoundErr "volume CAS type not found" | saveIf "getvoldetails.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.spec.storageClassName}" | trim | saveAs "getvoldetails.storageClassName" .TaskResult | noop -}}
+    {{- .TaskResult.getvoldetails.storageClassName | notFoundErr "storage class name not found for given volume" | saveIf "getvoldetails.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.spec.claimRef.namespace}" | trim | saveAs "getvoldetails.storageClassNamespace" .TaskResult | noop -}}
+    {{- .TaskResult.getvoldetails.storageClassNamespace | notFoundErr "storage class namespace not found for given volume" | saveIf "getvoldetails.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.spec.claimRef.namespace}" | trim | saveAs "getvoldetails.pvcNamespace" .TaskResult | noop -}}
+    {{- .TaskResult.getvoldetails.pvcNamespace | notFoundErr "pvc namespace not found for given volume" | saveIf "getvoldetails.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.spec.claimRef.name}" | trim | saveAs "getvoldetails.pvcName" .TaskResult | noop -}}
+    {{- .TaskResult.getvoldetails.pvcName | notFoundErr "pvc name not found for given volume" | saveIf "getvoldetails.notFoundErr" .TaskResult | noop -}}
+    {{ $retries := 0 -}}
+    {{- $message := printf "details for volume {%s} are : volCASType: {%s}, storageClassName: {%s}, storageClassNamespace: {%s}, pvcName: {%s}, pvcNamespace: {%s}" .UpgradeItem.name .TaskResult.getvoldetails.volCASType .TaskResult.getvoldetails.storageClassName .TaskResult.getvoldetails.storageClassNamespace .TaskResult.getvoldetails.pvcName .TaskResult.getvoldetails.pvcNamespace -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-get-vol-details" "Success" $message $retries now }}
+
+---
+
+# Get storage class resource version
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-get-sc-res-version
+  namespace: default
+spec:
+  meta: |
+    id: getstorageclassresversion
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    action: get
+    objectName: {{.TaskResult.getvoldetails.storageClassName}}
+    runNamespace: {{.TaskResult.getvoldetails.storageClassNamespace}}
+  post: |
+    {{- jsonpath .JsonResult "{.metadata.resourceVersion}" | trim | saveAs "getstorageclassresversion.storageClassResVersion" .TaskResult | noop -}}
+    {{- .TaskResult.getstorageclassresversion.storageClassResVersion | notFoundErr "storage class resource version not found" | saveIf "getstorageclassresversion.notFoundErr" .TaskResult | noop -}}
+    {{ $retries := 0 -}}
+    {{- $message := printf "resource version for storage class {%s} is : {%s}" .TaskResult.getvoldetails.storageClassName .TaskResult.getstorageclassresversion.storageClassResVersion -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-get-sc-res-version" "Success" $message $retries now }}
+
+---
+
+# list volume target deployment
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-list-target-deployment
+  namespace: default
+spec:
+  meta: |
+    id: listtargetdeployment
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: list
+    runNamespace: {{ .UpgradeItem.namespace }}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .UpgradeItem.name }},openebs.io/target=cstor-target
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "listtargetdeployment.targetDeploymentName" .TaskResult | noop -}}
+    {{- .TaskResult.listtargetdeployment.targetDeploymentName | notFoundErr "volume target deployment not found" | saveIf "listtargetdeployment.notFoundErr" .TaskResult | noop -}}
+    {{ $retries := 0 -}}
+    {{- $message := printf "the target deployment for this volume is : {%s}" .TaskResult.listtargetdeployment.targetDeploymentName -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-list-target-deployment" "Success" $message $retries now }}
+
+---
+
+# list target svc
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-list-target-svc
+  namespace: default
+spec:
+  meta: |
+    id: listtargetservice
+    apiVersion: v1
+    kind: Service
+    action: list
+    runNamespace: {{ .UpgradeItem.namespace }}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .UpgradeItem.name }},openebs.io/target-service=cstor-target-svc
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "listtargetservice.items" .TaskResult | noop -}}
+    {{- .TaskResult.listtargetservice.items | notFoundErr "volume target service not found" | saveIf "listtargetservice.notFoundErr" .TaskResult | noop -}}
+    {{ $retries := 0 -}}
+    {{- $message := printf "the target service for this volume is : {%s}" .TaskResult.listtargetservice.items -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-list-target-svc" "Success" $message $retries now }}
+
+---
+
+# list cstor volumes CR
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-list-cstorvolumecr
+  namespace: default
+spec:
+  meta: |
+    id: listcstorvolumecr
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolume
+    action: list
+    runNamespace: {{ .UpgradeItem.namespace }}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .UpgradeItem.name }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "listcstorvolumecr.items" .TaskResult | noop -}}
+    {{- .TaskResult.listcstorvolumecr.items | notFoundErr "cstor volume cr not found" | saveIf "listcstorvolumecr.notFoundErr" .TaskResult | noop -}}
+    {{ $retries := 0 -}}
+    {{- $message := printf "the CStorVolume list is : {%s}" .TaskResult.listcstorvolumecr.items -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-list-cstorvolumecr" "Success" $message $retries now }}
+
+---
+
+# list cstor volume replicas
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-list-cstorvolumereplicas	
+  namespace: default
+spec:
+  meta: |
+    id: listcstorvolumeReplicas
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolumeReplica
+    action: list
+    runNamespace: {{ .UpgradeItem.namespace }}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .UpgradeItem.name }}
+  post: |
+    {{- jsonpath .JsonResult "{range .items[*]}{@.metadata.name} {end}" | trim | saveAs "listcstorvolumeReplicas.items" .TaskResult | noop -}}
+    {{- .TaskResult.listcstorvolumeReplicas.items | notFoundErr "cstor volume replicas not found" | saveIf "listcstorvolumeReplicas.notFoundErr" .TaskResult | noop -}}
+    {{ $retries := 0 -}}
+    {{- $message := printf "the CStorVolumeReplica list is : {%s}" .TaskResult.listcstorvolumeReplicas.items -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-list-cstorvolumereplicas" "Success" $message $retries now }}
+
+
+---
+
+# list target older replicasets
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-list-target-old-rs
+  namespace: default
+spec:
+  meta: |
+    id: listtargetoldrs
+    apiVersion: extensions/v1beta1
+    kind: ReplicaSet
+    action: list
+    runNamespace: {{ .UpgradeItem.namespace }}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .UpgradeItem.name }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "listtargetoldrs.items" .TaskResult | noop -}}
+    {{- .TaskResult.listtargetoldrs.items | notFoundErr "older replicasets for volume target deployment not found" | saveIf "listtargetoldrs.notFoundErr" .TaskResult | noop -}}
+    {{ $retries := 0 -}}
+    {{- $message := printf "the older replicaset to be deleted after patching target {%s} is : {%s}" .TaskResult.listtargetdeployment.targetDeploymentName .TaskResult.listtargetoldrs.items -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-list-target-old-rs" "Success" $message $retries now }}
+
+---
+
+# ----------------------- Patching volume target deployment strategy to recreate ---------------------------------------
+#
+# Check the deployment for desired status
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-pre-check-deployment-rollout-status-strategy
+  namespace: default
+spec:
+  meta: |
+    id: precheckdeploymentstatusstrategy
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: rolloutstatus
+    objectName: {{ .TaskResult.listtargetdeployment.targetDeploymentName }}
+    runNamespace: {{ .UpgradeItem.namespace }}
+    retry: "20,20s"
+  post: |
+    {{- $rolledOut := jsonpath .JsonResult "{.isRolledout}" | trim -}}
+    {{- $rolloutMessage := jsonpath .JsonResult "{.message}" | trim -}}
+    {{- $endTime := now | date "2006-01-02T15:04:05Z07:00" -}}
+    {{- $retries := 0 -}}
+    {{- if eq $rolledOut "true" }}
+    {{- $status := "Success" -}}
+    {{- $message := "Pre check deployment rollout status for patching with recreate strategy passed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-pre-check-deployment-rollout-status-strategy" $status $message $retries now }}
+    {{- else }}
+    {{- $status := "Failed" -}}
+    {{- $message := "Pre check deployment rollout status for patching with recreate strategy failed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-pre-check-deployment-rollout-status-strategy" $status $message $retries now }}
+    {{- "waiting for deployment rollout" | saveAs "precheckdeploymentstatusstrategy.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+
+---
+
+# Patch volume target deployment strategy to recreate
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-patch-deployment-strategy
+  namespace: default
+spec:
+  meta: |
+    id: patchdeploymentstrategy
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    runNamespace: {{ .UpgradeItem.namespace }}
+    objectName: {{ .TaskResult.listtargetdeployment.targetDeploymentName }}
+    action: patch
+  post: |
+    {{ "Recreate" | saveAs "patchdeploymentstrategy.strategy" .TaskResult | noop -}}
+    {{ $retries := 0 -}}
+    {{- $message := printf "deployment {%s} has been patched with {%s} strategy." .TaskResult.listtargetdeployment.targetDeploymentName .TaskResult.patchdeploymentstrategy.strategy -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-patch-deployment-strategy" "Success" $message $retries now }}
+  task: |-
+    type: merge
+    pspec: |-
+      spec:
+        strategy:
+          rollingUpdate:
+          type: Recreate
+
+---
+
+# Post check target deployment rollout status after patching with recreate strategy
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-post-check-deployment-rollout-status-strategy
+  namespace: default
+spec:
+  meta: |
+    id: postcheckdeploymentstatusstrategy
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: rolloutstatus
+    objectName: {{ .TaskResult.listtargetdeployment.targetDeploymentName }}
+    runNamespace: {{ .UpgradeItem.namespace }}
+    retry: "20,20s"
+  post: |
+    {{- $rolledOut := jsonpath .JsonResult "{.isRolledout}" | trim -}}
+    {{- $rolloutMessage := jsonpath .JsonResult "{.message}" | trim -}}
+    {{- $endTime := now | date "2006-01-02T15:04:05Z07:00" -}}
+    {{- $retries := 0 -}}
+    {{- if eq $rolledOut "true" }}
+    {{- $status := "Success" -}}
+    {{- $message := "Post check deployment rollout status after patching with recreate strategy passed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "" "upgrade-cstor-volume-080-081-post-check-deployment-rollout-status-strategy" $status $message $retries now }}
+    {{- else }}
+    {{- $status := "Failed" -}}
+    {{- $message := "Post check deployment rollout status after patching with recreate strategy failed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-deployment-rollout-status-strategy" $status $message $retries now }}
+    {{- "waiting for deployment rollout" | saveAs "postcheckdeploymentstatusstrategy.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+
+---
+
+# Post check target deployment strategy if successfully patched to recreate or not
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-post-check-deployment-strategy-patch
+  namespace: default
+spec:
+  meta: |
+    id: postCheckDeploymentStrategyPatch
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: get
+    objectName: {{ .TaskResult.listtargetdeployment.targetDeploymentName }}
+    runNamespace: {{ .UpgradeItem.namespace }}
+  post: |
+    {{ $retries := 0 -}}
+    {{- $deploymentStrategy := jsonpath .JsonResult "{.spec.strategy.type}" | trim -}}
+    {{- if eq $deploymentStrategy .TaskResult.patchdeploymentstrategy.strategy }}
+    {{- $message := printf "post check after patching deployment {%s} with {%s} strategy has passed." .TaskResult.listtargetdeployment.targetDeploymentName .TaskResult.patchdeploymentstrategy.strategy -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-deployment-strategy-patch" "Success" $message $retries now }}
+    {{- else }}
+    {{- $message := printf "post check for patching deployment {%s} with {%s} strategy has failed." .TaskResult.listtargetdeployment.targetDeploymentName .TaskResult.patchdeploymentstrategy.strategy -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-deployment-strategy-patch" "Failed" $message $retries now }}
+    {{- "volume target deployment not patched with recreate strategy" | saveAs "postCheckDeploymentStrategyPatch.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+
+# ----------------------- Patched volume target deployment strategy to recreate ---------------------------------------/end
+---
+
+# ----------------------- Patching volume target deployment with latest images -----------------------------------------
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-patch-target-deployment-latest-versions
+  namespace: default
+spec:
+  meta: |
+    id: patchtargetdeploymentlatestversions
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    runNamespace: {{ .UpgradeItem.namespace }}
+    objectName: {{ .TaskResult.listtargetdeployment.targetDeploymentName }}
+    action: patch
+  post: |
+    {{ $retries := 0 -}}
+    {{- $message := printf "deployment {%s} has been patched with latest images for {%s} version." .TaskResult.listtargetdeployment.targetDeploymentName .Config.targetversion.value -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-patch-target-deployment-latest-versions" "Success" $message $retries now }}
+  task: |-
+    type: strategic
+    pspec: |-
+      metadata:
+        annotations: 
+          openebs.io/storage-class-ref: "name: {{ .TaskResult.getvoldetails.storageClassName }}\nresourceVersion: {{ .TaskResult.getstorageclassresversion.storageClassResVersion }}\n"
+        labels: 
+          openebs.io/version: {{ .Config.targetversion.value}}
+      spec: 
+        template: 
+          metadata: 
+            annotations: 
+              openebs.io/storage-class-ref: "name: {{ .TaskResult.getvoldetails.storageClassName }}\nresourceVersion: {{ .TaskResult.getstorageclassresversion.storageClassResVersion }}\n"
+            labels: 
+              openebs.io/storage-class: {{ .TaskResult.getvoldetails.storageClassName }}
+          spec: 
+            containers: 
+            - name: cstor-istgt
+              image: quay.io/openebs/cstor-istgt:{{ .Config.targetversion.value}}
+            - name: maya-volume-exporter
+              image: quay.io/openebs/m-exporter:{{ .Config.targetversion.value}}
+            - name: cstor-volume-mgmt
+              image: quay.io/openebs/cstor-volume-mgmt:{{ .Config.targetversion.value}}
+
+---
+
+# Post check target deployment rollout status after patching with latest versions
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-post-check-deployment-rollout-status-latest-versions
+  namespace: default
+spec:
+  meta: |
+    id: postcheckdeploymentstatuslatestversions
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: rolloutstatus
+    objectName: {{ .TaskResult.listtargetdeployment.targetDeploymentName }}
+    runNamespace: {{ .UpgradeItem.namespace }}
+    retry: "20,20s"
+  post: |
+    {{- $rolledOut := jsonpath .JsonResult "{.isRolledout}" | trim -}}
+    {{- $rolloutMessage := jsonpath .JsonResult "{.message}" | trim -}}
+    {{- $endTime := now | date "2006-01-02T15:04:05Z07:00" -}}
+    {{- $retries := 0 -}}
+    {{- if eq $rolledOut "true" }}
+    {{- $status := "Success" -}}
+    {{- $message := "Post check deployment rollout status after patching with latest versions passed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-deployment-rollout-status-latest-versions" $status $message $retries now }}
+    {{- else }}
+    {{- $status := "Failed" -}}
+    {{- $message := "Post check deployment rollout status after patching with latest versions failed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-deployment-rollout-status-latest-versions" $status $message $retries now }}
+    {{- "waiting for deployment rollout" | saveAs "postcheckdeploymentstatuslatestversions.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+
+---
+
+# Post check target deployment images patch with latest versions
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-post-check-patch-deployment-image
+  namespace: default
+spec:
+  meta: |
+    id: postCheckDeploymentImagePatch
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: get
+    objectName: {{ .TaskResult.listtargetdeployment.targetDeploymentName }}
+    runNamespace: {{ .UpgradeItem.namespace }}
+  post: |
+    {{- $passed := "true" -}}
+    {{- $cstorIstgtImage := jsonpath .JsonResult "{.spec.template.spec.containers[?(@.name=='cstor-istgt')].image}" | trim -}}
+    {{- $mayaVolExporterImage := jsonpath .JsonResult "{.spec.template.spec.containers[?(@.name=='maya-volume-exporter')].image}" | trim -}}
+    {{- $cstorVolMgmtImage := jsonpath .JsonResult "{.spec.template.spec.containers[?(@.name=='cstor-volume-mgmt')].image}" | trim -}}
+    {{- if contains .Config.targetversion.value $cstorIstgtImage }}
+    {{- else }}
+    {{- $passed = "false" -}}
+    {{- "cstor-istgt container image of volume target deployment not patched" | saveAs "postCheckDeploymentImagePatch.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if contains .Config.targetversion.value $mayaVolExporterImage }}
+    {{- else }}
+    {{- $passed = "false" -}}
+    {{- "maya-exporter container image of volume target deployment not patched" | saveAs "postCheckDeploymentImagePatch.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if contains .Config.targetversion.value $cstorVolMgmtImage }}
+    {{- else }}
+    {{- $passed = "false" -}}
+    {{- "cstor-volume-mgmt container image of volume target deployment not patched" | saveAs "postCheckDeploymentImagePatch.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{ $retries := 0 -}}
+    {{- if eq $passed "true" -}}
+    {{- $message := printf "post check for patching deployment {%s} with latest images for target version {%s} has passed." .TaskResult.listtargetdeployment.targetDeploymentName .Config.targetversion.value -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-patch-deployment-image" "Success" $message $retries now }}
+    {{- else -}}
+    {{- $message := printf "post check for patching deployment {%s} with latest images for target version {%s} has failed." .TaskResult.listtargetdeployment.targetDeploymentName .Config.targetversion.value -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-patch-deployment-image" "Failed" $message $retries now }}
+    {{- end }}
+
+# ------------------------- Patched volume target deployment with latest versions ---------------------------------------/end
+---
+
+# ------------------------- Patching target svc ---------------------------------------------------------------------
+# Patch target service
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-patch-target-svc
+  namespace: default
+spec:
+  meta: |
+    id: patchtargetsvc
+    apiVersion: v1
+    kind: Service
+    runNamespace: {{ .UpgradeItem.namespace }}
+    objectName: {{ .TaskResult.listtargetservice.items }}
+    action: patch
+  post: |
+    {{ $retries := 0 -}}
+    {{- $message := printf "service {%s} has been patched with required labels and annotations." .TaskResult.listtargetservice.items -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-patch-target-svc" "Success" $message $retries now }}
+  task: |-
+    type: merge
+    pspec: |-
+      metadata:
+        annotations: 
+          openebs.io/storage-class-ref: "name: {{ .TaskResult.getvoldetails.storageClassName }}\nresourceVersion: {{ .TaskResult.getstorageclassresversion.storageClassResVersion }}\n"
+        labels: 
+          openebs.io/version: {{ .Config.targetversion.value }}
+
+---
+
+# Post check for target svc after patch
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-post-check-target-svc
+  namespace: default
+spec:
+  meta: |
+    id: postchecktargetsvc
+    apiVersion: v1
+    kind: Service
+    action: get
+    objectName: {{ .TaskResult.listtargetservice.items }}
+    runNamespace: {{ .UpgradeItem.namespace }}
+  post: |
+    {{- $scrAnnotation := jsonpath .JsonResult "{.metadata.annotations.openebs\\.io/storage-class-ref}" | trim | saveAs "scrAnnotation" .TaskResult | noop -}}
+    {{- $labels := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/version}" | trim | saveAs "labels" .TaskResult | noop -}}
+    {{- $desiredAnnotation := printf "name: %s\nresourceVersion: %s\n" .TaskResult.getvoldetails.storageClassName .TaskResult.getstorageclassresversion.storageClassResVersion | saveAs "desAnnotation" .TaskResult | noop -}}
+    {{- $retries := 0 -}}
+    {{- if contains .TaskResult.getvoldetails.storageClassName .TaskResult.scrAnnotation -}}
+    {{- else -}}
+    {{- $status := "Failed" -}}
+    {{- $message := "Post check for target service after patching failed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-target-svc" $status $message $retries now }}
+    {{- "annotations not patched for volume target service" | saveAs "postchecktargetsvc.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    
+    {{- if eq "0.8.1" .TaskResult.labels -}}
+    {{- $status := "Success" -}}
+    {{- $message := "Post check for target service after patching passed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-target-svc" $status $message $retries now }}
+    {{- else -}}
+    {{- $status := "Failed" -}}
+    {{- $message := "Post check target service after patching failed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-target-svc" $status $message $retries now }}
+    {{- "labels not patched for volume target service" | saveAs "postchecktargetsvc.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+
+# ------------------------- Patched target svc -------------------------------------------------------------------\end
+---
+
+# Patch cstor volume cr
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-patch-cstor-volume-cr
+  namespace: default
+spec:
+  meta: |
+    id: patchcstorvolumecr
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolume
+    runNamespace: {{ .UpgradeItem.namespace }}
+    objectName: {{ .TaskResult.listcstorvolumecr.items }}
+    action: patch
+  post: |
+    {{ $retries := 0 -}}
+    {{- $message := printf "cstor volume {%s} has been patched with required labels and annotations." .TaskResult.listcstorvolumecr.items -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-patch-cstor-volume-cr" "Success" $message $retries now }}
+  task: |-
+    type: merge
+    pspec: |-
+      metadata:
+        annotations: 
+          openebs.io/storage-class-ref: "name: {{ .TaskResult.getvoldetails.storageClassName }}\nresourceVersion: {{ .TaskResult.getstorageclassresversion.storageClassResVersion }}\n"
+        labels: 
+          openebs.io/version: {{ .Config.targetversion.value }}
+
+---
+
+# Post check for cstor volume cr after patch
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-post-check-cstor-volume-cr
+  namespace: default
+spec:
+  meta: |
+    id: postcheckcstorvolumecr
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolume
+    action: get
+    objectName: {{ .TaskResult.listcstorvolumecr.items }}
+    runNamespace: {{ .UpgradeItem.namespace }}
+  post: |
+    {{- $scrAnnotation := jsonpath .JsonResult "{.metadata.annotations.openebs\\.io/storage-class-ref}" | trim | saveAs "scrAnnotation" .TaskResult | noop -}}
+    {{- $labels := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/version}" | trim | saveAs "labels" .TaskResult | noop -}}
+    {{- $desiredAnnotation := printf "name: %s\nresourceVersion: %s\n" .TaskResult.getvoldetails.storageClassName .TaskResult.getstorageclassresversion.storageClassResVersion | saveAs "desAnnotation" .TaskResult | noop -}}
+    {{- $retries := 0 -}}
+    {{- if contains .TaskResult.getvoldetails.storageClassName .TaskResult.scrAnnotation -}}
+    {{- else -}}
+    {{- $status := "Failed" -}}
+    {{- $message := "Post check cstor volume cr after patching failed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-cstor-volume-cr" $status $message $retries now }}
+    {{- "annotations not patched for cstor volume cr" | saveAs "postcheckcstorvolumecr.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    
+    {{- if eq "0.8.1" .TaskResult.labels -}}
+    {{- $status := "Success" -}}
+    {{- $message := "Post check cstor volume cr after patching passed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-cstor-volume-cr" $status $message $retries now }}
+    {{- else }}
+    {{- $status := "Failed" -}}
+    {{- $message := "Post check cstor volume cr after patching failed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-cstor-volume-cr" $status $message $retries now }}
+    {{- "labels not patched for cstor volume cr" | saveAs "postcheckcstorvolumecr.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+
+# ------------------------- Patched cstor volume cr -------------------------------------------------------------------\end
+---
+
+# Patch cstor volume replicas
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-patch-cstor-volume-replica
+  namespace: default
+spec:
+  meta: |
+    {{- $cstorVolReplicaList := .TaskResult.listcstorvolumeReplicas.items | default "" | splitList " " -}}
+    id: patchcstorvolumereplicacr
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolumeReplica
+    runNamespace: {{ .UpgradeItem.namespace }}
+    action: patch
+    repeatWith:
+      metas:
+      {{- range $k, $cvr := $cstorVolReplicaList }}
+      - objectName: {{ $cvr }}
+      {{- end }}
+  post: |
+    {{ $retries := 0 -}}
+    {{- $message := printf "cstor volume replicas {%s} has been patched with required labels and annotations." .TaskResult.listcstorvolumeReplicas.items -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-patch-cstor-volume-replica" "Success" $message $retries now }}
+  task: |-
+    type: merge
+    pspec: |-
+      metadata:
+        annotations: 
+          openebs.io/storage-class-ref: "name: {{ .TaskResult.getvoldetails.storageClassName }}\nresourceVersion: {{ .TaskResult.getstorageclassresversion.storageClassResVersion }}\n"
+        labels: 
+          openebs.io/version: {{ .Config.targetversion.value }}
+
+---
+
+# Post check for cstor volume replicas after patch
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-post-check-cstor-volume-replicas
+  namespace: default
+spec:
+  meta: |
+    id: postcheckcstorvolumereplicas
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolumeReplica
+    action: list
+    runNamespace: {{ .UpgradeItem.namespace }}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .UpgradeItem.name }}
+  post: |
+    {{- $retries := 0 -}}
+    {{- $upgradeResultName := .UpgradeItem.upgradeResult | default "" -}}
+    {{- $upgradeResultNamespace := .UpgradeItem.namespace | default "" -}}
+    {{- $cvrAnnotationLabels := jsonpath .JsonResult "{range .items[*]}pkey={@.metadata.name},scrAnnotation={@.metadata.annotations.openebs\\.io/storage-class-ref},labels={@..metadata.labels.openebs\\.io/version};{end}" | trim | default "" | splitList ";" -}}
+    {{- $cvrAnnotationLabels | keyMap "cvrList" .ListItems | noop -}}
+    {{- range $pkey, $map := .ListItems.cvrList }}
+    {{- $pkey := $pkey }}
+    {{- $map := $map }}
+    {{- $scrAnnotation := pluck "scrAnnotation" $map | first | trim | default "" | saveAs "scrAnnotation" .TaskResult }}
+    {{- $labels := pluck "labels" $map | first | trim | default "" | saveAs "labels" .TaskResult }}
+    {{- if contains "openebs-cstor-sparse" $scrAnnotation -}}
+    {{- else -}}
+    {{- $status := "Failed" -}}
+    {{- $message := "Post check cstor volume replicas after patching failed" -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-post-check-cstor-volume-replicas" $status $message $retries now }}
+    {{- "annotations not patched for cstor volume replicas" | saveAs "postcheckcstorvolumereplicas.verifyErr" .TaskResult | noop -}}
+    {{- end -}}
+    {{- if contains "0.8.1" $labels -}}
+    {{- $status := "Success" -}}
+    {{- $message := "Post check cstor volume replicas after patching passed" -}}
+    {{- updateUpgradeResult $upgradeResultName "default" "upgrade-cstor-volume-080-081-post-check-cstor-volume-replicas" $status $message $retries now }}
+    {{- else -}}
+    {{- $status := "Failed" -}}
+    {{- $message := "Post check cstor volume replicas after patching failed" -}}
+    {{- updateUpgradeResult $upgradeResultName "default" "upgrade-cstor-volume-080-081-post-check-cstor-volume-replicas" $status $message $retries now }}
+    {{- "labels not patched for cstor volume replicas" | saveAs "postcheckcstorvolumereplicas.verifyErr" .TaskResult | noop -}}
+    {{- end -}}
+    {{- end -}}
+
+# ------------------------- Patched cstor volume replicas -------------------------------------------------------------------\end
+
+---
+
+# Delete older replicasets of volume target deployment
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: upgrade-cstor-volume-080-081-delete-target-old-replicaset
+  namespace: default
+spec:
+  meta: | 
+    {{- $rslist := .TaskResult.listtargetoldrs.items | default "" | splitList " " -}}
+    id: deletereplicaset
+    apiVersion: extensions/v1beta1
+    kind: ReplicaSet
+    runNamespace: {{ .UpgradeItem.namespace }}
+    action: delete
+    repeatWith:
+      metas:
+      {{- range $k, $rs := $rslist }}
+      - objectName: {{ $rs }}
+      {{- end }}
+  post: |
+    {{ $retries := 0 -}}
+    {{- $message := printf "older replicasets i.e. {%s} has been deleted." .TaskResult.listtargetoldrs.items -}}
+    {{- updateUpgradeResult .UpgradeItem.upgradeResult "default" "upgrade-cstor-volume-080-081-delete-target-old-replicaset" "Success" $message $retries now }}
+

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/main.go
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/maya/pkg/client/k8s"
+	"github.com/openebs/maya/pkg/engine"
+	mach_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type testEngine struct {
+	engine        engine.Interface  // generic CAS template engine
+	defaultConfig []v1alpha1.Config // default cas storagepool config found in CASTemplate
+	openebsConfig []v1alpha1.Config // openebsConfig is the config that is provided
+}
+
+func main() {
+	newK8sClient, err := k8s.NewK8sClient("")
+	if err != nil {
+		fmt.Println("error in getting clientset")
+		fmt.Println(err)
+
+		return
+	}
+
+	key := "demo-vol-template"
+	cast, err := newK8sClient.GetOEV1alpha1CAST(key, mach_apis_meta_v1.GetOptions{})
+	if err != nil {
+		fmt.Println("error in getting cas template")
+		fmt.Println(err)
+	}
+	engine, err := engine.New(
+		cast,
+		key,
+		map[string]interface{}{},
+	)
+	if err != nil {
+		fmt.Println("error in creating machine")
+		fmt.Println(err)
+	}
+
+	// fetch data from engine execution
+	data, err := engine.Run()
+	if err != nil {
+		fmt.Println("error in executing machine")
+		fmt.Println(err)
+	}
+
+	fmt.Println(string(data))
+}

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtask-crd.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtask-crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: runtasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: RunTask
+    listKind: RunTaskList
+    plural: runtasks
+    shortNames:
+    - rtask
+    singular: runtask
+  scope: Namespaced
+  version: v1alpha1

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/delete-target-replicaset.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/delete-target-replicaset.yaml
@@ -1,0 +1,18 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: delete-target-old-replicaset
+  namespace: default
+spec:
+  meta: | 
+    {{- $rslist := .TaskResult.target_older_rs | default "" | splitList " " -}}
+    id: deletereplicaset
+    apiVersion: extensions/v1beta1
+    kind: ReplicaSet
+    runNamespace: {{ .Config.namespace.value }}
+    action: delete
+    repeatWith:
+      metas:
+      {{- range $k, $rs := $rslist }}
+      - objectName: {{ $rs }}
+      {{- end }}

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/deployment_rollout_status.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/deployment_rollout_status.yaml
@@ -1,0 +1,46 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: deploy-rollout-status
+  namespace: default
+spec:
+  meta: |
+    {{- $depname := .TaskResult.ctrl_deployment | default "" -}}
+    id: deployrolloutstatus
+    runNamespace: {{ .Config.namespace.value }}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: get
+    objectName: {{ $depname }}
+    retry: "20,120s"
+  post: |
+    {{- $replicas := .TaskResult.replicacount | default "" -}}
+    {{- $updatedReplicas := .TaskResult.updatedReplicacount | default "" -}}
+    {{- $readyReplicas := .TaskResult.readyReplicacount | default "" -}}
+    {{- $availableReplicas := .TaskResult.availableReplicacount | default "" -}}
+    {{- "" | saveAs "verifyErr" .TaskResult | noop -}}
+    {{- if eq $replicas "" }}
+    {{- "replica count not  present" | saveAs "deployrolloutstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if eq $updatedReplicas "" }}
+    {{- "updated replica count not  present" | saveAs "deployrolloutstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if eq $readyReplicas "" }}
+    {{- "ready replica count not  present" | saveAs "deployrolloutstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if eq $availableReplicas "" }}
+    {{- "available replica count not  present" | saveAs "deployrolloutstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if ne $replicas $updatedReplicas }}
+    {{- "replica count is not equal with updated replica count" | saveAs "deployrolloutstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if ne $replicas $readyReplicas }}
+    {{- "replica count is not equal with ready replica count" | saveAs "deployrolloutstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- if ne $replicas $availableReplicas }}
+    {{- "replica count is not equal with available replica count" | saveAs "deployrolloutstatus.verifyErr" .TaskResult | noop -}}
+    {{- end }}
+    {{- jsonpath .JsonResult "{.status.replicas}" | trim | saveAs "replicacount" .TaskResult | default "" noop -}}
+    {{- jsonpath .JsonResult "{.status.updatedReplicas}" | trim | saveAs "updatedReplicacount" .TaskResult | default "" noop -}}
+    {{- jsonpath .JsonResult "{.status.readyReplicas}" | trim | saveAs "readyReplicacount" .TaskResult | default "" noop -}}
+    {{- jsonpath .JsonResult "{.status.availableReplicas}" | trim | saveAs "availableReplicacount" .TaskResult | default "" noop -}}

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/get-vol-info.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/get-vol-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: get-vol-info
+  namespace: default
+spec:
+  meta: |
+    id: getvolinfo
+    apiVersion: v1
+    kind: PersistentVolume
+    action: get
+    objectName: {{.Config.pvName.value}}
+  post: |-
+    '{{- jsonpath .JsonResult "{.metadata.annotations.openebs\\.io/cas-type}" | trim | saveAs "vol_cas_type" .TaskResult | noop -}}'
+    '{{- jsonpath .JsonResult "{.spec.storageClassName}" | trim | saveAs "sc_name" .TaskResult | noop -}}'
+    '{{- jsonpath .JsonResult "{.spec.claimRef.namespace}" | trim | saveAs "sc_namespace" .TaskResult | noop -}}'

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/get_sc_resVersion.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/get_sc_resVersion.yaml
@@ -1,0 +1,15 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: get-sc-res-version
+  namespace: default
+spec:
+  meta: |
+    id: getstorageclassresversion
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    action: get
+    objectName: {{.TaskResult.sc_name}}
+    runNamespace: {{.TaskResult.sc_namespace}}
+  post: |-
+    '{{- jsonpath .JsonResult "{.metadata.resourceVersion}" | trim | saveAs "sc_res_version" .TaskResult | noop -}}'

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_cstor_volume_replicas.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_cstor_volume_replicas.yaml
@@ -1,0 +1,17 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: list-cstor-volume-replicas	
+  namespace: default
+spec:
+  meta: |
+    id: listcstorvolumeReplicas
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolumeReplica
+    action: list
+    runNamespace: {{.Config.namespace.value}}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .Config.pvName.value }}
+  post: |-
+    '{{- jsonpath .JsonResult "{range .items[*]}{@.metadata.name} {end}" | trim | saveAs "cstor_volume_replicas" .TaskResult | noop -}}'
+

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_cstor_volumes_cr.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_cstor_volumes_cr.yaml
@@ -1,0 +1,17 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: list-cstor-volumes-cr
+  namespace: default
+spec:
+  meta: |
+    id: listcstorvolumescr
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolume
+    action: list
+    runNamespace: {{.Config.namespace.value}}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .Config.pvName.value }}
+  post: |-
+    '{{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "cstor_volumes" .TaskResult | noop -}}'
+

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_ctrl_deploy.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_ctrl_deploy.yaml
@@ -1,0 +1,17 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: list-ctrl-deployment
+  namespace: default
+spec:
+  meta: |
+    id: listctrldeployment
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: list
+    runNamespace: {{.Config.namespace.value}}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .Config.pvName.value }},openebs.io/target=cstor-target
+  post: |-
+    '{{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "ctrl_deployment" .TaskResult | noop -}}'
+

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_ctrl_svc.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_ctrl_svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: list-ctrl-svc
+  namespace: default
+spec:
+  meta: |
+    id: listctrlservice
+    apiVersion: v1
+    kind: Service
+    action: list
+    runNamespace: {{.Config.namespace.value}}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .Config.pvName.value }},openebs.io/target-service=cstor-target-svc
+  post: |-
+    '{{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "ctrl_svc" .TaskResult | noop -}}'
+

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_target_old_rs.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/list_target_old_rs.yaml
@@ -1,0 +1,16 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: list-target-old-rs
+  namespace: default
+spec:
+  meta: |
+    id: listtargetoldrs
+    apiVersion: extensions/v1beta1
+    kind: ReplicaSet
+    action: list
+    runNamespace: {{ .Config.namespace.value }}
+    options: |-
+      labelSelector: openebs.io/persistent-volume={{ .Config.pvName.value }}
+  post: |-
+    '{{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "target_older_rs" .TaskResult | noop -}}'

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-cstor-volume-CR.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-cstor-volume-CR.yaml
@@ -1,0 +1,21 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: patch-cstor-volume-cr
+  namespace: default
+spec:
+  meta: |
+    id: patchcstorvolumecr
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolume
+    runNamespace: {{ .Config.namespace.value }}
+    objectName: {{ .TaskResult.cstor_volumes }}
+    action: patch
+  task: |-
+    type: merge
+    pspec: |-
+      metadata:
+        annotations: 
+          openebs.io/storage-class-ref: "name: {{ .TaskResult.sc_name }}\nresourceVersion: {{ .TaskResult.sc_res_version }}\n"
+        labels: 
+          openebs.io/version: {{ .Config.targetVersion.value }}

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-cstor-volume-replicaCR.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-cstor-volume-replicaCR.yaml
@@ -1,0 +1,26 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: patch-cstor-volume-replica
+  namespace: default
+spec:
+  meta: |
+    {{- $cstorVolReplicaList := .TaskResult.cstor_volume_replicas | default "" | splitList " " -}}
+    id: patchcstorvolumereplicacr
+    apiVersion: openebs.io/v1alpha1
+    kind: CStorVolumeReplica
+    runNamespace: {{ .Config.namespace.value }}
+    action: patch
+    repeatWith:
+      metas:
+      {{- range $k, $cvr := $cstorVolReplicaList }}
+      - objectName: {{ $cvr }}
+      {{- end }}
+  task: |-
+    type: merge
+    pspec: |-
+      metadata:
+        annotations: 
+          openebs.io/storage-class-ref: "name: {{ .TaskResult.sc_name }}\nresourceVersion: {{ .TaskResult.sc_res_version }}\n"
+        labels: 
+          openebs.io/version: {{ .Config.targetVersion.value }}

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-dep-recreate-strategy.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-dep-recreate-strategy.yaml
@@ -1,0 +1,20 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: patch-deployment-recreate-strategy
+  namespace: default
+spec:
+  meta: |
+    id: patchdeployment
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    runNamespace: {{ .Config.namespace.value }}
+    objectName: {{ .TaskResult.ctrl_deployment }}
+    action: patch
+  task: |-
+    type: merge
+    pspec: |-
+      spec:
+        strategy:
+          rollingUpdate:
+          type: Recreate

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-target-deploy.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-target-deploy.yaml
@@ -1,0 +1,36 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: patch-target-deployment
+  namespace: default
+spec:
+  meta: |
+    id: patchtargetdeployment
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    runNamespace: {{ .Config.namespace.value }}
+    objectName: {{ .TaskResult.ctrl_deployment }}
+    action: patch
+  task: |-
+    type: strategic
+    pspec: |-
+      metadata:
+        annotations: 
+          openebs.io/storage-class-ref: "name: {{ .TaskResult.sc_name }}\nresourceVersion: {{ .TaskResult.sc_res_version }}\n"
+        labels: 
+          openebs.io/version: {{ .Config.targetVersion.value}}
+      spec: 
+        template: 
+          metadata: 
+            annotations: 
+              openebs.io/storage-class-ref: "name: {{ .TaskResult.sc_name }}\nresourceVersion: {{ .TaskResult.sc_res_version }}\n"
+            labels: 
+              openebs.io/storage-class: {{ .TaskResult.sc_name }}
+          spec: 
+            containers: 
+            - name: cstor-istgt
+              image: quay.io/openebs/cstor-istgt:{{ .Config.targetVersion.value}}
+            - name: maya-volume-exporter
+              image: quay.io/openebs/m-exporter:{{ .Config.targetVersion.value}}
+            - name: cstor-volume-mgmt
+              image: quay.io/openebs/cstor-volume-mgmt:{{ .Config.targetVersion.value}}

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-target-svc.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks/patch-target-svc.yaml
@@ -1,0 +1,21 @@
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: patch-target-svc
+  namespace: default
+spec:
+  meta: |
+    id: patchtargetsvc
+    apiVersion: v1
+    kind: Service
+    runNamespace: {{ .Config.namespace.value }}
+    objectName: {{ .TaskResult.ctrl_svc }}
+    action: patch
+  task: |-
+    type: merge
+    pspec: |-
+      metadata:
+        annotations: 
+          openebs.io/storage-class-ref: "name: {{ .TaskResult.sc_name }}\nresourceVersion: {{ .TaskResult.sc_res_version }}\n"
+        labels: 
+          openebs.io/version: {{ .Config.targetVersion.value }}

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/service-account.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/service-account.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-admin
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: casTemplate
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: cluster-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/ubuntu-pod.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/ubuntu-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu
+spec:
+  serviceAccountName: cluster-admin
+  containers:
+  - name: ubuntu
+    image: ubuntu:latest
+    # Just spin & wait forever
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 30; done;" ]

--- a/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/volume-upgrade-job.yaml
+++ b/openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/volume-upgrade-job.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upgrade-config
+  namespace: default
+data:
+  upgrade: |
+    casTemplate: cstor-volume-update-080-081
+    resources:
+    - name: pvc-42eba9ce-718a-11e9-98c5-42010a80023a
+      kind: cstor-volume
+      namespace: openebs
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: volume-upgrade
+spec:
+  template:
+    spec:
+      serviceAccountName: cluster-admin
+      containers:
+      - name:  oupgrade
+        image: sagarkrsd/m-upgrade:ci
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        env:
+        - name: OPENEBS_IO_SELF_NAME
+          value: volume-upgrade
+          #valueFrom:
+            #fieldRef:
+              #fieldPath: metadata.name
+        - name: OPENEBS_IO_SELF_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_IO_SELF_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+      volumes:
+      - name: config
+        configMap:
+          name: upgrade-config
+      restartPolicy: Never
+


### PR DESCRIPTION
This PR contains all the required runtasks to upgrade cstor volumes from **0.8.0** to **0.8.1**.

To test this you need to create a util binary that can execute one castemplate. File main.go contains a small code that can run one castemplate. You can do dep init and dep ensure and build your binary but most of the task support are not available yet so i have added one sample binary that can execute a castemplate with all the required supports. Template name must be demo-vol-temlate. You can create a ubuntu pod and copy this binary inside that pod and run it. You can bring up a testing setup by using yamls and code inside **openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates** folder.

Apply all runtasks present inside **openebs-upgrade/0.8.0-0.8.1/cstor-volume-upgrade/cas-templates/runtasks** folder. You can get pv name doing `kubectl get pv` and put it in demo-template.yaml default config. 
Using these runtasks you can upgrade cstor volumes one by one.

**NOTE**: The latest added runtasks, cas-template and upgrade job yaml is subject to change as per new changes introduced in env variables for upgrade-job yaml and cas-template runtime config variables.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>